### PR TITLE
Remove dead node.js demo link

### DIFF
--- a/content/v3/oauth.md
+++ b/content/v3/oauth.md
@@ -132,4 +132,3 @@ links that might be of help:
 * [Ruby OmniAuth example](http://github.com/intridea/omniauth)
 * [Ruby Sinatra extension](http://github.com/atmos/sinatra_auth_github)
 * [Ruby Warden strategy](http://github.com/atmos/warden-github)
-* [Node.js demo using Nozzle](http://github.com/fictorial/nozzle/blob/master/demo/08-github-oauth2.js)


### PR DESCRIPTION
The fictorial/nozzle repository no longer exists and I couldn't find any forks which contained the file the link originally pointed to.
