### PR TITLE
Typos in the pull request API documentation

### DIFF
--- a/content/v3/pulls.md
+++ b/content/v3/pulls.md
@@ -10,7 +10,7 @@ can read more about the use of mimes types in the API
 
 ## List pull requests
 
-    GET /repo/:user/:repo/pulls
+    GET /repos/:user/:repo/pulls
 
 ### Parameters
 
@@ -25,7 +25,7 @@ is `open`.
 
 ## Get a single pull request
 
-    GET /repo/:user/:repo/pulls/:id
+    GET /repos/:user/:repo/pulls/:number
 
 ### Response
 


### PR DESCRIPTION
/repo/:user/:repo/ should be /repos/:user/:repo/
I guess that is true everywhere, but I only tried listing all pull request and showing a single one.
Also, pull requests seem to have numbers, not ids.
