### PR TITLE
Typo on blog and developer doc: opend => opened

### DIFF
--- a/content/v3/repos/hooks.md
+++ b/content/v3/repos/hooks.md
@@ -15,7 +15,7 @@ The default event is `push`.  The available events are:
 * `issues` - Any time an Issue is opened or closed.
 * `issue_comment` - Any time an Issue is commented on.
 * `commit_comment` - Any time a Commit is commented on.
-* `pull_request` - Any time a Pull Request is opend, closed, or
+* `pull_request` - Any time a Pull Request is opened, closed, or
   synchronized (updated due to a new push in the branch that the pull
 request is tracking).
 * `gollum` - Any time a Wiki page is updated.


### PR DESCRIPTION
The blog post @ https://github.com/blog/964-all-of-the-hooks and the developer doc @ http://developer.github.com/v3/repos/hooks/ has a minor typo (opend vs opened).

Cheers,
  Lee :beer:

/cc @technoweenie

![octoKitteh](http://images.icanhascheezburger.com/completestore/2008/7/28/englishmajorki128617323904460783.jpg)
