### PR TITLE
Add a direct link to register an app. 

### DIFF
--- a/content/index.md
+++ b/content/index.md
@@ -13,3 +13,6 @@ For the new API v3, start browsing the resources on the right >>
 View the [API Changelog](/v3/changelog) for information on existing and
 planned changes to the API.
 
+# Useful links
+
+[Register an application](https://github.com/account/applications/new)


### PR DESCRIPTION
Hi. 

I had a hard time finding this link. Felt it should have been on the front page of the api.
