### PR TITLE
Change token keys to the "new" token keys.

### DIFF
--- a/content/v3.md
+++ b/content/v3.md
@@ -144,13 +144,13 @@ $ curl -u "username:PASSWORD" https://api.github.com
 OAuth2 Token (sent in a header):
 
 <pre class="terminal">
-$ curl -H "Authorization: token OAUTH-TOKEN" https://api.github.com
+$ curl -H "Token: OAUTH-TOKEN" https://api.github.com
 </pre>
 
 OAuth2 Token (sent as a parameter):
 
 <pre class="terminal">
-$ curl https://api.github.com?access_token=OAUTH-TOKEN
+$ curl https://api.github.com?token=OAUTH-TOKEN
 </pre>
 
 Read [more about OAuth2](/v3/oauth/).


### PR DESCRIPTION
- Authorization header to Token
- Query access_token to token.
  Signed-off-by: Jordon Bedwell jordon@envygeeks.com

Today while playing with the API I noticed that it would only accept Token for each.
