### PR TITLE
Fixed a typo in the api docs.

### DIFF
--- a/content/v3/users.md
+++ b/content/v3/users.md
@@ -6,7 +6,7 @@ title: Users | GitHub API
 
 Many of the resources on the users API provide a shortcut for getting
 information about the currently authenticated user. If a request URL
-does not include a `:user` parameter than the response will be for the
+does not include a `:user` parameter then the response will be for the
 logged in user (and you must pass [authentication
 information](/v3/#authentication) with your request).
 


### PR DESCRIPTION
"If a request URL does not include a :user parameter _than_ the response will be for the logged in user (and you must pass authentication information with your request)."

Changed than to then.
