### PR TITLE
Updated docs to reflect the fact that the /contributors call returns the...

### DIFF
--- a/content/v3/repos.md
+++ b/content/v3/repos.md
@@ -176,7 +176,7 @@ in results.
 ### Response
 
 <%= headers 200 %>
-<%= json(:user) { |h| [h] } %>
+<%= json(:contributor) { |h| [h] } %>
 
 ## List languages
 

--- a/lib/resources.rb
+++ b/lib/resources.rb
@@ -63,6 +63,10 @@ module GitHub
       "url"          => "https://api.github.com/users/octocat"
     }
 
+    CONTRIBUTOR = USER.merge({
+      "contributions" => 32
+    })
+
     FULL_USER = USER.merge({
       "name"         => "monalisa octocat",
       "company"      => "GitHub",


### PR DESCRIPTION
... number of contributions, not a straight User JSON response.
