### PR TITLE
Add note to verbs explaination about PUT and empty body requests

### DIFF
--- a/content/v3.md
+++ b/content/v3.md
@@ -126,7 +126,8 @@ relatively new and uncommon HTTP verb, so resource endpoints also accept
 POST requests.
 
 PUT
-: Used for replacing resources or collections.
+: Used for replacing resources or collections. For PUT requests
+with no `body` attribute, be sure to set the `Content-Length` header to zero. 
 
 DELETE
 : Used for deleting resources.


### PR DESCRIPTION
When making a request via PUT with an empty body, the content-length header
needs to be set to zero.

See http://developer.github.com/v3/orgs/teams/#add-team-member as an example of a PUT request with empty body
