### PR TITLE
Add reference to required scope for managing private Gists.

### DIFF
--- a/content/v3/gists.md
+++ b/content/v3/gists.md
@@ -4,6 +4,14 @@ title: Gists | GitHub API
 
 # Gists API
 
+## Authentication
+
+You can read public gists and create them for anonymous users without a token; however, to read or write gists on a user's behalf the **gists** [oAuth scope][1] is required.
+
+<!-- When an oAuth client does not have the gists scope, the API will return a 404 "Not Found" response regardless of the validity of the credentials. 
+
+The API will return a 401 "Bad credentials" response if the gists scope was given to the application but the credentials are invalid. -->
+
 ## List gists
 
 List a user's gists:
@@ -152,3 +160,5 @@ including the filename with a null hash.
 ### Response
 
 <%= headers 204 %>
+
+[1] http://developer.github.com/v3/oauth/#scopes


### PR DESCRIPTION
I recently hit a brick wall developing with the Gists API due to some 404's being returned for the /gists endpoint, not realizing that Github had the concept of scope and that I was missing it.

Staff behind support@github.com helped me work through my mistake. This was my bad for not seeing that in the OAuth docs but based on my research of the issue I think [I'm not the only one][1] to have made the error. 

I think someday returning something like a 401 "Forbidden" might help clue in developers like myself who skipped over the scope section, but in the meantime I'm hoping this commit might be able to pay back the support cost I incurred Github by preventing others from making my same error.

[1] https://github.com/blog/846-new-issues-and-gist-api#comment-13057
