### PR TITLE
Fixed the heading and anchor link text for the "CommitCommentEvent" (was...

### DIFF
--- a/content/v3/events/types.md
+++ b/content/v3/events/types.md
@@ -14,7 +14,7 @@ organization (if applicable).
 Note that some of these events may not be rendered in timelines.
 They're only created for various internal and repository hooks.
 
-* <a href="#commitcommentevent">CommitComment</a>
+* <a href="#commitcommentevent">CommitCommentEvent</a>
 * <a href="#createevent">CreateEvent</a>
 * <a href="#deleteevent">DeleteEvent</a>
 * <a href="#downloadevent">DownloadEvent</a>
@@ -32,7 +32,7 @@ They're only created for various internal and repository hooks.
 * <a href="#teamaddevent">TeamAddEvent</a>
 * <a href="#watchevent">WatchEvent</a>
 
-## CommitComment
+## CommitCommentEvent
 
 Hook name: `commit_comment`
 


### PR DESCRIPTION
... "CommitComment").

I noticed on the list of event types on the v3 API documentation, the `CommitCommentEvent` was labelled as `CommitComment`. I'm pretty sure this is wrong since I've seen tons of `CommitCommentEvent` events in the wild, but no `CommitComment` events.
