### PR TITLE
fix a typo that didn't create a link

### DIFF
--- a/content/v3/gists.md
+++ b/content/v3/gists.md
@@ -161,4 +161,4 @@ including the filename with a null hash.
 
 <%= headers 204 %>
 
-[1] http://developer.github.com/v3/oauth/#scopes
+[1]: http://developer.github.com/v3/oauth/#scopes


### PR DESCRIPTION
I noticed a semi colon was missing that prevented markdown from creating a link to the oAuth scopes page.
