### PR TITLE
adds the ajaxorg github library for NodeJS to the list

### DIFF
--- a/content/v3/libraries.md
+++ b/content/v3/libraries.md
@@ -44,8 +44,10 @@ GitHub v3 API.  Builds are available in [Maven Central](http://search.maven.org/
 
 ## Javascript
 
+* [JavaScript GitHub API for Node.JS][github] (`npm install github`)
 * [NodeJS GitHub library][octonode]
 
+[github]: https://github.com/ajaxorg/node-github
 [octonode]: https://github.com/pksunkara/octonode
 
 ## Perl


### PR DESCRIPTION
... which covers the API 100%, with docs at http://ajaxorg.github.com/node-github/, including pagination and rate limit handling.

I hope you like it!
