### PR TITLE
Add USER to the List Pull Requests example.

### DIFF
--- a/lib/resources.rb
+++ b/lib/resources.rb
@@ -182,7 +182,8 @@ module GitHub
           "https://api.github.com/octocat/Hello-World/issues/1/comments"},
         "review_comments" => {'href' =>
           "https://api.github.com/octocat/Hello-World/pulls/1/comments"}
-      }
+      },
+      "user" => USER
     }
 
     FULL_PULL = PULL.merge({


### PR DESCRIPTION
The live `/repos/:user/:repo/pulls` action includes the user which opened the pull request. This is not currently documented. This patch fixes that.

See: https://api.github.com/repos/octocat/Hello-World/pulls?state=closed
And: http://developer.github.com/v3/pulls/#list-pull-requests
