### PR TITLE
Corrected progit.org → git-scm.com URLs which have changed.

### DIFF
--- a/content/v3/git.md
+++ b/content/v3/git.md
@@ -17,10 +17,10 @@ Git DB API functions will return a 409 if the git repo for a Repository is empty
 or unavailable.  This typically means it is being created still.  [Contact
 Support](https://github.com/contact) if this response status persists.
 
-![git db](http://progit.org/figures/ch9/18333fig0904-tn.png)
+![git db](http://git-scm.com/figures/18333fig0904-tn.png)
 
 For more information on the Git object database, please read the 
-<a href="http://progit.org/book/ch9-0.html">Git Internals</a> chapter of
+<a href="http://git-scm.com/book/ch9-0.html">Git Internals</a> chapter of
 the Pro Git book.
 
 As an example, if you wanted to commit a change to a file in your

--- a/content/v3/git/import.md
+++ b/content/v3/git/import.md
@@ -8,7 +8,7 @@ title: Git Import | GitHub API
 
 Would this be cool?
 
-See the [Pro Git book](http://progit.org/book/ch8-2.html#a_custom_importer) or the
+See the [Pro Git book](http://git-scm.com/book/ch8-2.html#a_custom_importer) or the
 [fast-import man page](http://www.kernel.org/pub/software/scm/git/docs/git-fast-import.html)
 for more information about the fast-import syntax.
 


### PR DESCRIPTION
This includes a broken image URL which was not redirecting.
