### PR TITLE
Small addition to make clear alternative enterprise API entrypoint

### DIFF
--- a/content/v3.md
+++ b/content/v3.md
@@ -22,7 +22,8 @@ you have any problems or requests please contact
 ## Schema
 
 All API access is over HTTPS, and accessed from the `api.github.com`
-domain.  All data is sent and received as JSON.
+domain (or through `yourdomain.com/api/v3/` for enterprise).  All data is
+sent and received as JSON.
 
 <pre class="terminal">
 $ curl -i https://api.github.com


### PR DESCRIPTION
Our enterprise install does not have an api subdomain. As a result I was not able to access the v3 API, untill I found a comment (now deleted) on the google-cache of a github blogpost. Not the most ideal way to find out. Added an entry in the introduction about this alternative entrypoint.
