### PR TITLE
`private` is a valid type when listing org repos

### DIFF
--- a/content/v3/repos.md
+++ b/content/v3/repos.md
@@ -41,7 +41,7 @@ List repositories for the specified org.
 ### Parameters
 
 type
-: `all`, `public`, `member`. Default: `all`.
+: `all`, `public`, `member`, `private`. Default: `all`.
 
 ### Response
 


### PR DESCRIPTION
The `private` type option appears to be valid, accepted and working for listing an organization's private repositories, but it isn't documented... this pull request adds it to the list of options.

Thanks for your consideration, @pvdb
