### PR TITLE
Remove duplicated json definition

### DIFF
--- a/lib/resources.rb
+++ b/lib/resources.rb
@@ -565,32 +565,6 @@ module GitHub
       } ]
     }
 
-    COMMIT = {
-      "sha" => "7638417db6d59f3c431d3e1f261cc637155684cd",
-      "url" => "https://api.github.com/repos/octocat/Hello-World/git/commits/7638417db6d59f3c431d3e1f261cc637155684cd",
-      "author" => {
-        "date" => "2010-04-10T14:10:01-07:00",
-        "name" => "Scott Chacon",
-        "email" => "schacon@gmail.com"
-      },
-      "committer" => {
-        "date" => "2010-04-10T14:10:01-07:00",
-        "name" => "Scott Chacon",
-        "email" => "schacon@gmail.com"
-      },
-      "message" => "added readme, because im a good github citizen\n",
-      "tree" => {
-        "url" => "https://api.github.com/repos/octocat/Hello-World/git/trees/691272480426f78a0138979dd3ce63b77f706feb",
-        "sha" => "691272480426f78a0138979dd3ce63b77f706feb"
-      },
-      "parents" => [
-        {
-          "url" => "https://api.github.com/repos/octocat/Hello-World/git/commits/1acc419d4d6a9ce985db7be48c6349a0475975b5",
-          "sha" => "1acc419d4d6a9ce985db7be48c6349a0475975b5"
-        }
-      ]
-    }
-
     NEW_COMMIT = {
       "sha" => "7638417db6d59f3c431d3e1f261cc637155684cd",
       "url" => "https://api.github.com/repos/octocat/Hello-World/git/commits/7638417db6d59f3c431d3e1f261cc637155684cd",


### PR DESCRIPTION
The constant variable `COMMIT` is duplicated.
And both of them are different.
I removed incorrect one.

This patch fixes the format of the followings:
- http://developer.github.com/v3/repos/commits/#list-commits-on-a-repository
