### PR TITLE
Fix Repo Comments listing on a single commit

### DIFF
--- a/content/v3/repos/comments.md
+++ b/content/v3/repos/comments.md
@@ -25,7 +25,7 @@ Comments are ordered by ascending ID.
 ### Response
 
 <%= headers 200 %>
-<%= json(:commit_comment) %>
+<%= json(:commit_comment) { |h| [h] } %>
 
 ## Create a commit comment
 


### PR DESCRIPTION
Listing the comments on a single commit should be the same as listing commit
comments for a repository.
