### PR TITLE
Add jacquev6/PyGithub in libraries

### DIFF
--- a/content/v3/libraries.md
+++ b/content/v3/libraries.md
@@ -71,8 +71,10 @@ GitHub v3 API.  Builds are available in [Maven Central](http://search.maven.org/
 
 ## Python
 
+* [PyGithub][jacquev6_pygithub]
 * [Pygithub3][pygithub3-api]
 
+[jacquev6_pygithub]: https://github.com/jacquev6/PyGithub
 [pygithub3-api]: https://github.com/copitux/python-github3
 
 ## Ruby


### PR DESCRIPTION
Hello,

I just released version 1.0 of https://github.com/jacquev6/PyGithub and I would like it listed in http://developer.github.com/v3/libraries/#python

Thanks,
