### PR TITLE
Use pygments.rb instead of pygmentize

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gem 'nanoc', '~> 3.3.7'
 gem 'kramdown', '~> 0.13.2'
 gem 'nokogiri', '~> 1.4.4'
 gem 'yajl-ruby', '~> 0.8.2'
-gem 'pygmentize', '~> 0.0.3'
+gem 'pygments.rb'
 gem 'mime-types', '~> 1.16'
 gem 'coderay'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,18 +3,24 @@ GEM
   specs:
     adsf (1.1.1)
       rack (>= 1.0.0)
+    blankslate (2.1.2.4)
     coderay (1.0.6)
     colored (1.2)
     cri (2.3.0)
       colored (>= 1.2)
+    ffi (1.0.11)
     kramdown (0.13.7)
     mime-types (1.18)
     nanoc (3.3.7)
       cri (~> 2.2)
     nokogiri (1.4.7)
-    pygmentize (0.0.3)
+    pygments.rb (0.2.12)
+      rubypython (~> 0.5.3)
     rack (1.4.1)
     rake (0.9.2.2)
+    rubypython (0.5.3)
+      blankslate (>= 2.1.2.3)
+      ffi (~> 1.0.7)
     yajl-ruby (0.8.3)
 
 PLATFORMS
@@ -27,6 +33,6 @@ DEPENDENCIES
   mime-types (~> 1.16)
   nanoc (~> 3.3.7)
   nokogiri (~> 1.4.4)
-  pygmentize (~> 0.0.3)
+  pygments.rb
   rake (~> 0.9.2)
   yajl-ruby (~> 0.8.2)

--- a/Rules
+++ b/Rules
@@ -17,7 +17,7 @@ compile '*' do
   filter :erb
   filter :kramdown
   filter :colorize_syntax,
-    :colorizers => {:javascript => :pygmentize}
+    :colorizers => {:javascript => :pygmentsrb}
   layout 'default'
 end
 


### PR DESCRIPTION
This pull request lets the site use [pygments.rb](https://github.com/tmm1/pygments.rb) instead of `pygmentize` for syntax coloring. `pygments.rb` support is new in nanoc 3.3, so the Gemfile has been updated to make use of the latest nanoc version.

This change cuts down site compilation speed quite significantly.

Before: 294.59s
After: 2.54s
