### PR TITLE
/git/ should not be in these path specs

### DIFF
--- a/content/v3/git/commits.md
+++ b/content/v3/git/commits.md
@@ -6,7 +6,7 @@ title: Git Commits | GitHub API
 
 ## Get a Commit
 
-    GET /repos/:user/:repo/git/commits/:sha
+    GET /repos/:user/:repo/commits/:sha
 
 ### Response
 
@@ -15,7 +15,7 @@ title: Git Commits | GitHub API
 
 ## Create a Commit
 
-    POST /repos/:user/:repo/git/commits
+    POST /repos/:user/:repo/commits
 
 ### Parameters
 


### PR DESCRIPTION
Hey guys I noticed that these uris don't actual have "git" in their paths. I updated the docs with working paths

```
https://api.github.com/repos/meetup/widgets/commits/master?callback=foo
```
