### PR TITLE
Never tell users to type their password into the command

### DIFF
--- a/content/v3.md
+++ b/content/v3.md
@@ -142,7 +142,7 @@ There are two ways to authenticate through GitHub API v3:
 Basic Authentication:
 
 <pre class="terminal">
-$ curl -u "username:PASSWORD" https://api.github.com
+$ curl -u "username" https://api.github.com
 </pre>
 
 OAuth2 Token (sent in a header):

--- a/content/v3/repos/hooks.md
+++ b/content/v3/repos/hooks.md
@@ -193,7 +193,7 @@ The GitHub PubSubHubbub endpoint is: https://api.github.com/hub.
 PubSubHubbub endpoint, but not change the `hub.topic` URI format.) A
 successful request with curl looks like:
 
-    curl -u "user:password" -i \
+    curl -u "user" -i \
       https://api.github.com/hub \
       -F "hub.mode=subscribe" \
       -F "hub.topic=https://github.com/:user/:repo/events/push" \


### PR DESCRIPTION
Curl will prompt for it, this avoids saving the password as plaintext
in the shell command history.
