### PR TITLE
Fix typo on repos/contents

### DIFF
--- a/content/v3/repos/contents.md
+++ b/content/v3/repos/contents.md
@@ -33,6 +33,7 @@ This method returns the contents of any file or directory in a repository.
 
 path
 : _Optional_ **string** - The content path.
+
 ref
 : _Optional_ **string** - The String name of the Commit/Branch/Tag.  Defaults to `master`.
 


### PR DESCRIPTION
Without this empty line, 'ref' was appearing at the end of the path description here http://developer.github.com/v3/repos/contents/#get-contents
