### PR TITLE
Make rvm use 1.9.3.

### DIFF
--- a/.rvmrc
+++ b/.rvmrc
@@ -1,1 +1,1 @@
-rvm ruby-1.9.2
+rvm ruby-1.9.3


### PR DESCRIPTION
`. rbenv-version` uses 1.9.3. so should `.rvmrc`.
