### PR TITLE
Make CNAME a proper nanoc item

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -11,12 +11,6 @@ task :publish => [:clean] do
 
   sh "nanoc compile"
 
-  # this should not be necessary, but I can't figure out how to
-  # just keep a goddamn static file in the root with nanoc
-  File.open("output/CNAME", 'w+') do |f|
-    f.puts("developer.github.com")
-  end
-
   ENV['GIT_DIR'] = File.expand_path(`git rev-parse --git-dir`.chomp)
   old_sha = `git rev-parse refs/remotes/origin/gh-pages`.chomp
   Dir.chdir('output') do

--- a/Rules
+++ b/Rules
@@ -13,6 +13,9 @@
 compile '/static/*' do
 end
 
+compile '/CNAME/' do
+end
+
 compile '*' do
   filter :erb
   filter :kramdown
@@ -23,6 +26,10 @@ end
 
 route '/static/*' do
   item.identifier[7..-2]
+end
+
+route '/CNAME/' do
+  '/CNAME'
 end
 
 route '*' do

--- a/content/CNAME
+++ b/content/CNAME
@@ -1,0 +1,1 @@
+developer.github.com


### PR DESCRIPTION
CNAME is currently generated by the “publish” rake task, but it is cleaner to have it as a proper nanoc item.
