### PR TITLE
Fixed a plural in the scope name.

### DIFF
--- a/content/v3/gists.md
+++ b/content/v3/gists.md
@@ -6,7 +6,7 @@ title: Gists | GitHub API
 
 ## Authentication
 
-You can read public gists and create them for anonymous users without a token; however, to read or write gists on a user's behalf the **gists** [oAuth scope][1] is required.
+You can read public gists and create them for anonymous users without a token; however, to read or write gists on a user's behalf the **gist** [oAuth scope][1] is required.
 
 <!-- When an oAuth client does not have the gists scope, the API will return a 404 "Not Found" response regardless of the validity of the credentials. 
 


### PR DESCRIPTION
I've had a lot of trobuble today due to this plural, see gist https://gist.github.com/9b2169dacacceb1dfc8b.

Support contacted me to say that the scope is "gist" (not "gists" as reported here).

Moreover, I think that the API should be fixed so that a 401 is returned instead of a 404 (as described in the commented part).
