### PR TITLE
Update reference to source tarball downloads to link to /repos/contents, ...

### DIFF
--- a/content/v3/repos/downloads.md
+++ b/content/v3/repos/downloads.md
@@ -5,7 +5,7 @@ title: Repo Downloads | GitHub API
 # Repo Downloads API
 
 The downloads API is for package downloads only. If you want to get
-source tarballs for tags you should use [this](/v3/repos/#list-tags)
+source tarballs you should use [this](/repos/contents/#get-archive-link)
 instead.
 
 ## List downloads for a repository


### PR DESCRIPTION
...which can work with any git ref.
