### PR TITLE
Added a description for the language API call.

### DIFF
--- a/content/v3/repos.md
+++ b/content/v3/repos.md
@@ -187,6 +187,8 @@ in results.
 
 ## List languages
 
+List languages for the specified repository. The value on the right of a language is the number of bytes of code written in that language.
+
     GET /repos/:user/:repo/languages
 
 ### Response


### PR DESCRIPTION
The languages API call returns the number of bytes of code written in that language. It wasn't clear in the documentation. So added a description for the same.
