### PR TITLE
Remove `commit_id` from create endpoint on repos/comments.md

### DIFF
--- a/content/v3/repos/comments.md
+++ b/content/v3/repos/comments.md
@@ -36,9 +36,6 @@ Comments are ordered by ascending ID.
 body
 : _Required_ **string**
 
-commit_id
-: _Required_ **string** - Sha of the commit to comment on.
-
 path
 : _Required_ **string** - Relative path of the file to comment on.
 


### PR DESCRIPTION
The sha is already in the url and not needed in the POST body.
