### PR TITLE
Add information about Blobs provided by the API

### DIFF
--- a/content/v3/git/blobs.md
+++ b/content/v3/git/blobs.md
@@ -19,7 +19,11 @@ read more about the use of mime types in the API [here](/v3/mime/).
 ### Response
 
 <%= headers 200 %>
-<%= json :content => "Content of the blob", :encoding => "utf-8" %>
+<%= json
+    :content => "Content of the blob",
+    :encoding => "utf-8",
+    :sha => "3a0f86fb8db8eea7ccbb9a95f325ddbedfb25e15",
+    :size => 100 %>
 
 ## Create a Blob
 


### PR DESCRIPTION
Seems these two attributes were not documented. I only found them by accident.
