### PR TITLE
Fix the API Changes link on homepage of developer.github.com

### DIFF
--- a/content/index.md
+++ b/content/index.md
@@ -10,7 +10,7 @@ you have any problems or requests please contact
 
 For the new API v3, start browsing the resources on the right >>
 
-View the [API Changelog](/v3/changelog) for information on existing and
+View the [API Changelog](#changes) for information on existing and
 planned changes to the API.
 
 ## Current Version
@@ -30,7 +30,7 @@ issue](https://github.com/contact) if you have problems.
 
 The API is expected to be finalized Real Soon Now.
 
-#### Expected Changes
+#### Expected Changes <a name="changes"></a>
 
 * All `*_url` attributes move to a `_links` object.  See [Pull
   Requests](/v3/pulls/#get-a-single-pull-request) for an example.


### PR DESCRIPTION
The API changes link on the homepage of the Developer site points to a page that points back to the homepage. I have updated it to link to the changes section on the homepage.
