### PR TITLE
Json-p fails because of bad encoding

### DIFF
--- a/content/v3.md
+++ b/content/v3.md
@@ -350,4 +350,10 @@ A link that looks like this:
 <%= json "Link" => [
   ["url1", {:rel => "next"}],
   ["url2", {:rel => "foo", :bar => "baz"}]] %>
+  
+Note that Json-p will not always work. Example:
+
+<pre>
+$.getJSON("https://api.github.com/repos/wycats/yard?callback=?")
+</pre>
 


### PR DESCRIPTION
This request returns bad javascript (the json is fine, but jsonp is not): https://api.github.com/repos/wycats/yard

The problem is that on the description, after the dot on "or the Ruby programming language.  It enables" there is a non valid Javascript character.
