### PR TITLE
draft of watcher api changes

### DIFF
--- a/content/changelog/2012-8-30-blah.html
+++ b/content/changelog/2012-8-30-blah.html
@@ -20,7 +20,7 @@ The current [Repository Starring][starring-api] methods look like this:
 
 * `/repos/:owner/:repo/watchers` - A list of users starring the repository.
 * `/users/:user/watched` - A list of repositories that a user has starred.
-* `/users/watched` - A list of repositories the current user has starred.
+* `/user/watched` - A list of repositories the current user has starred.
 
 [starring-api]: http://developer.github.com/v3/repos/watching/
 
@@ -30,7 +30,7 @@ In addition to this, we'll expose Watchers as "Subscriptions".  This is to
 keep from clashing with the legacy endpoint.
 
 * `/repos/:owner/:repo/subscribers` - A list of users watching the repository.
-* `/users/subscriptions` - A list of repositories the current user is watching.
+* `/user/subscriptions` - A list of repositories the current user is watching.
 
 Note: we don't plan to expose what other users are watching.
 
@@ -38,7 +38,7 @@ We'll also add a copy of the legacy Watchers API in the new endpoint:
 
 * `/repos/:owner/:repo/stargazers` - A list of users starring the repository.
 * `/users/:user/starred` - A list of repositories that a user has starred.
-* `/users/starred` - A list of repositories the current user has starred.
+* `/user/starred` - A list of repositories the current user has starred.
 
 This will be done with the current mime type for the API:
 
@@ -48,14 +48,14 @@ If you care about your application not breaking, make sure all outgoing API
 requests pass that value for the "Accept" header.
 
     # Accesses a user's starred repositories.
-    curl https://api.github.com/users/watched \
+    curl https://api.github.com/user/watched \
       -H "Accept: application/vnd.github.beta+json"
 
 ## Phase 2: Switch `/watchers` API Endpoint
 
 The "watch" endpoints will now be a copy of the "subscription" endpoints.  You
-will have to use `/users/starred` to get a user's starred repositories, not
-`/users/watched`.
+will have to use `/user/starred` to get a user's starred repositories, not
+`/user/watched`.
 
 This requires a new mime type value:
 
@@ -66,7 +66,7 @@ gracefully upgrade their applications by specifying the new mime value for the
 Accept header.
 
     # Accesses a user's watched repositories.
-    curl https://api.github.com/users/watched \
+    curl https://api.github.com/user/watched \
       -H "Accept: application/vnd.github.v3+json"
 
 ## Phase 3: Remove `/subscribers` API Endpoint.


### PR DESCRIPTION
This is the first post for an API changelog, detailing the phased rollout of the watcher API changes that we plan to do.

/cc @github/api
