### PR TITLE
add TOC to every page

### DIFF
--- a/Rules
+++ b/Rules
@@ -18,7 +18,7 @@ end
 
 compile '/feed/' do
   filter :erb
-  filter :kramdown
+  filter :kramdown, :toc_levels => [2]
   filter :colorize_syntax,
     :colorizers => {:javascript => :pygmentsrb}
 end
@@ -26,7 +26,7 @@ end
 %w(v3 */).each do |version|
   compile "/changes/#{version}" do
     filter :erb
-    filter :kramdown
+    filter :kramdown, :toc_levels => [2]
     filter :colorize_syntax,
       :colorizers => {:javascript => :pygmentsrb}
     layout 'changes' if version[0] == '*'
@@ -36,7 +36,7 @@ end
 
 compile '*' do
   filter :erb
-  filter :kramdown
+  filter :kramdown, :toc_levels => [2]
   filter :colorize_syntax,
     :colorizers => {:javascript => :pygmentsrb}
   layout 'default'

--- a/content/v3.md
+++ b/content/v3.md
@@ -8,15 +8,8 @@ This describes the resources that make up the official GitHub API v3. If
 you have any problems or requests please contact
 [support](mailto:support@github.com?subject=APIv3).
 
-* <a href="#schema">Schema</a>
-* <a href="#client-errors">Client Errors</a>
-* <a href="#http-verbs">HTTP Verbs</a>
-* <a href="#authentication">Authentication</a>
-* <a href="#pagination">Pagination</a>
-* <a href="#rate-limiting">Rate Limiting</a>
-* <a href="#conditional-requests">Conditional Requests</a>
-* <a href="#cross-origin-resource-sharing">Cross Origin Resource Sharing</a>
-* <a href="#json-p-callbacks">JSON-P Callbacks</a>
+* TOC
+{:toc}
 
 ## Schema
 

--- a/content/v3/events.md
+++ b/content/v3/events.md
@@ -7,6 +7,9 @@ title: Events | GitHub API
 This is a read-only API to the GitHub events.  These events power the
 various activity streams on the site.
 
+* TOC
+{:toc}
+
 Events support [pagination](/v3/#pagination),
 however the `per_page` option is unsupported. The fixed page size is 30 items.
 Fetching up to ten pages is supported, for a total of 300 events.

--- a/content/v3/events/types.md
+++ b/content/v3/events/types.md
@@ -14,24 +14,8 @@ organization (if applicable).
 Note that some of these events may not be rendered in timelines.
 They're only created for various internal and repository hooks.
 
-* <a href="#commitcommentevent">CommitCommentEvent</a>
-* <a href="#createevent">CreateEvent</a>
-* <a href="#deleteevent">DeleteEvent</a>
-* <a href="#downloadevent">DownloadEvent</a>
-* <a href="#followevent">FollowEvent</a>
-* <a href="#forkevent">ForkEvent</a>
-* <a href="#forkapplyevent">ForkApplyEvent</a>
-* <a href="#gistevent">GistEvent</a>
-* <a href="#gollumevent">GollumEvent</a>
-* <a href="#issuecommentevent">IssueCommentEvent</a>
-* <a href="#issuesevent">IssuesEvent</a>
-* <a href="#memberevent">MemberEvent</a>
-* <a href="#publicevent">PublicEvent</a>
-* <a href="#pullrequestevent">PullRequestEvent</a>
-* <a href="#pullrequestreviewcommentevent">PullRequestReviewCommentEvent</a>
-* <a href="#pushevent">PushEvent</a>
-* <a href="#teamaddevent">TeamAddEvent</a>
-* <a href="#watchevent">WatchEvent</a>
+* TOC
+{:toc}
 
 ## CommitCommentEvent
 

--- a/content/v3/gists.md
+++ b/content/v3/gists.md
@@ -4,6 +4,9 @@ title: Gists | GitHub API
 
 # Gists API
 
+* TOC
+{:toc}
+
 ## Authentication
 
 You can read public gists and create them for anonymous users without a token; however, to read or write gists on a user's behalf the **gist** [oAuth scope][1] is required.

--- a/content/v3/gists/comments.md
+++ b/content/v3/gists/comments.md
@@ -4,6 +4,9 @@ title: Gist Comments | GitHub API
 
 # Gist Comments API
 
+* TOC
+{:toc}
+
 Gist Comments leverage [these](#custom-mime-types) custom mime types.
 You can read more about the use of mime types in the API
 [here](/v3/mime/).

--- a/content/v3/git/blobs.md
+++ b/content/v3/git/blobs.md
@@ -4,6 +4,9 @@ title: Git Blobs | GitHub API
 
 # Blobs API
 
+* TOC
+{:toc}
+
 Since blobs can be any arbitrary binary data, the input and responses
 for the blob API takes an encoding parameter that can be either `utf-8`
 or `base64`.  If your data cannot be losslessly sent as a UTF-8 string,

--- a/content/v3/git/commits.md
+++ b/content/v3/git/commits.md
@@ -4,6 +4,9 @@ title: Git Commits | GitHub API
 
 # Commits API
 
+* TOC
+{:toc}
+
 ## Get a Commit
 
     GET /repos/:user/:repo/git/commits/:sha

--- a/content/v3/git/refs.md
+++ b/content/v3/git/refs.md
@@ -4,6 +4,9 @@ title: Git Refs | GitHub API
 
 # References API
 
+* TOC
+{:toc}
+
 ## Get a Reference
 
     GET /repos/:user/:repo/git/refs/:ref

--- a/content/v3/git/tags.md
+++ b/content/v3/git/tags.md
@@ -4,6 +4,9 @@ title: Git Tags | GitHub API
 
 # Tags API
 
+* TOC
+{:toc}
+
 This tags API only deals with tag objects - so only annotated tags, not
 lightweight tags.
 

--- a/content/v3/git/trees.md
+++ b/content/v3/git/trees.md
@@ -4,6 +4,9 @@ title: Git Trees | GitHub API
 
 # Trees API
 
+* TOC
+{:toc}
+
 ## Get a Tree
 
     GET /repos/:user/:repo/git/trees/:sha

--- a/content/v3/issues.md
+++ b/content/v3/issues.md
@@ -4,6 +4,9 @@ title: Issues | GitHub API
 
 # Issues API
 
+* TOC
+{:toc}
+
 Issues leverage [these](#custom-mime-types) custom mime types. You can
 read more about the use of mime types in the API [here](/v3/mime/).
 

--- a/content/v3/issues/assignees.md
+++ b/content/v3/issues/assignees.md
@@ -4,6 +4,9 @@ title: Issue Assignees | GitHub API
 
 # Assignees API
 
+* TOC
+{:toc}
+
 ## List assignees
 
 This call lists all the available assignees (owner + collaborators) to which

--- a/content/v3/issues/comments.md
+++ b/content/v3/issues/comments.md
@@ -4,6 +4,9 @@ title: Issue Comments | GitHub API
 
 # Issue Comments API
 
+* TOC
+{:toc}
+
 The Issue Comments API supports listing, viewing, editing, and creating
 comments on issues and pull requests.
 

--- a/content/v3/issues/events.md
+++ b/content/v3/issues/events.md
@@ -4,6 +4,9 @@ title: Issue Events | GitHub API
 
 # Issue Events API
 
+* TOC
+{:toc}
+
 Records various events that occur around an Issue or Pull Request. This is
 useful both for display on issue/pull request information pages and also to
 determine who should be notified of comments.

--- a/content/v3/issues/labels.md
+++ b/content/v3/issues/labels.md
@@ -4,6 +4,9 @@ title: Issue Labels | GitHub API
 
 # Labels API
 
+* TOC
+{:toc}
+
 ## List all labels for this repository
 
     GET /repos/:user/:repo/labels

--- a/content/v3/issues/milestones.md
+++ b/content/v3/issues/milestones.md
@@ -4,6 +4,9 @@ title: Issue Milestones | GitHub API
 
 # Milestones API
 
+* TOC
+{:toc}
+
 ## List milestones for a repository
 
     GET /repos/:user/:repo/milestones

--- a/content/v3/markdown.md
+++ b/content/v3/markdown.md
@@ -4,6 +4,9 @@ title: Markdown Rendering | GitHub API
 
 # Markdown Rendering API
 
+* TOC
+{:toc}
+
 ## Render an arbitrary Markdown document
 
 	POST /markdown
@@ -34,7 +37,7 @@ context
 	%(<p>Hello world <a href="http://github.com/github/linguist/issues/1" class="issue-link" title="This is a simple issue">github/linguist#1</a> <strong>cool</strong>, and <a href="http://github.com/github/gollum/issues/1" class="issue-link" title="This is another issue">#1</a>!</p>), 200
 %>
 
-# Render a Markdown document in raw mode
+## Render a Markdown document in raw mode
 
 	POST /markdown/raw
 

--- a/content/v3/oauth.md
+++ b/content/v3/oauth.md
@@ -4,6 +4,9 @@ title: OAuth | GitHub API
 
 # OAuth
 
+* TOC
+{:toc}
+
 OAuth2 is a protocol that lets external apps request authorization to
 private details in a user's GitHub account without getting their
 password. This is preferred over Basic Authentication because tokens can

--- a/content/v3/orgs.md
+++ b/content/v3/orgs.md
@@ -4,7 +4,10 @@ title: Organizations | GitHub API
 
 # Orgs API
 
-## List
+* TOC
+{:toc}
+
+## List User Organizations
 
 List all public organizations for a user.
 
@@ -19,7 +22,7 @@ List public and private organizations for the authenticated user.
 <%= headers 200, :pagination => true %>
 <%= json(:org) { |h| [h] } %>
 
-## Get
+## Get an Organizations
 
     GET /orgs/:org
 
@@ -28,7 +31,7 @@ List public and private organizations for the authenticated user.
 <%= headers 200 %>
 <%= json(:full_org) %>
 
-## Edit
+## Edit an Organization
 
     PATCH /orgs/:org
 

--- a/content/v3/orgs/members.md
+++ b/content/v3/orgs/members.md
@@ -4,6 +4,9 @@ title: Organization Members | GitHub API
 
 # Org Members API
 
+* TOC
+{:toc}
+
 ## List members
 
 List all users who are members of an organization. A member is a user

--- a/content/v3/orgs/teams.md
+++ b/content/v3/orgs/teams.md
@@ -4,6 +4,9 @@ title: Organization Teams | GitHub API
 
 # Org Teams API
 
+* TOC
+{:toc}
+
 All actions against teams require at a minimum an authenticated user who
 is a member of the owner's team in the `:org` being managed. Additionally,
 OAuth users require "user" [scope](/v3/oauth/#scopes).

--- a/content/v3/pulls.md
+++ b/content/v3/pulls.md
@@ -4,6 +4,9 @@ title: Pull Requests | GitHub API
 
 # Pull Request API
 
+* TOC
+{:toc}
+
 The Pull Request API allows you to list, view, edit, create, and even merge
 pull requests. Comments on pull requests can be managed via the [Issue
 Comments API](/v3/issues/comments/).

--- a/content/v3/pulls/comments.md
+++ b/content/v3/pulls/comments.md
@@ -4,6 +4,9 @@ title: Pull Request Comments | GitHub API
 
 # Pull Request Review Comments API
 
+* TOC
+{:toc}
+
 Pull Request Review Comments are comments on a portion of the unified
 diff.  These are separate from Commit Comments (which are applied
 directly to a commit, outside of the Pull Request view), and Issue

--- a/content/v3/repos.md
+++ b/content/v3/repos.md
@@ -4,6 +4,9 @@ title: Repos | GitHub API
 
 # Repos API
 
+* TOC
+{:toc}
+
 ## List your repositories
 
 List repositories for the authenticated user.

--- a/content/v3/repos/collaborators.md
+++ b/content/v3/repos/collaborators.md
@@ -4,6 +4,9 @@ title: Repo Collaborators | GitHub API
 
 # Repo Collaborators API
 
+* TOC
+{:toc}
+
 ## List
 
     GET /repos/:user/:repo/collaborators

--- a/content/v3/repos/comments.md
+++ b/content/v3/repos/comments.md
@@ -4,6 +4,9 @@ title: Repo Comments | GitHub API
 
 # Repo Comments API
 
+* TOC
+{:toc}
+
 ## List commit comments for a repository
 
 Commit Comments leverage [these](#custom-mime-types) custom mime types. You can

--- a/content/v3/repos/commits.md
+++ b/content/v3/repos/commits.md
@@ -4,6 +4,9 @@ title: Repo Commits | GitHub API
 
 # Repo Commits API
 
+* TOC
+{:toc}
+
 The Repo Commits API supports listing, viewing, and comparing commits in a repository.
 
 ## List commits on a repository

--- a/content/v3/repos/contents.md
+++ b/content/v3/repos/contents.md
@@ -4,6 +4,9 @@ title: Repo Contents | GitHub API
 
 # Repo Contents API
 
+* TOC
+{:toc}
+
 These API methods let you retrieve the contents of files within a repository as
 Base64 encoded content. See [Mime types](/v3/mime) for requesting raw or other formats.
 

--- a/content/v3/repos/downloads.md
+++ b/content/v3/repos/downloads.md
@@ -4,6 +4,9 @@ title: Repo Downloads | GitHub API
 
 # Repo Downloads API
 
+* TOC
+{:toc}
+
 The downloads API is for package downloads only. If you want to get
 source tarballs you should use [this](/repos/contents/#get-archive-link)
 instead.

--- a/content/v3/repos/forks.md
+++ b/content/v3/repos/forks.md
@@ -4,6 +4,9 @@ title: Repo Forks | GitHub API
 
 # Repo Forks API
 
+* TOC
+{:toc}
+
 ## List forks
 
     GET /repos/:user/:repo/forks

--- a/content/v3/repos/hooks.md
+++ b/content/v3/repos/hooks.md
@@ -4,6 +4,9 @@ title: Repo Hooks | GitHub API
 
 # Repo Hooks API
 
+* TOC
+{:toc}
+
 The Repository Hooks API manages the post-receive web and service hooks
 for a repository.  There are two main APIs to manage these hooks: a JSON
 HTTP API, and [PubSubHubbub](#pubsubhubbub).

--- a/content/v3/repos/keys.md
+++ b/content/v3/repos/keys.md
@@ -4,6 +4,9 @@ title: Repo Deploy Keys | GitHub API
 
 # Repo Deploy Keys API
 
+* TOC
+{:toc}
+
 ## List
 
     GET /repos/:user/:repo/keys

--- a/content/v3/repos/merging.md
+++ b/content/v3/repos/merging.md
@@ -4,6 +4,9 @@ title: Repo Merging | GitHub API
 
 # Repo Merging API
 
+* TOC
+{:toc}
+
 The Repo Merging API supports merging branches in a repository. This accomplishes
 essentially the same thing as merging one branch into another in a local repository
 and then pushing to GitHub. The benefit is that the merge is done on the server side

--- a/content/v3/repos/statuses.md
+++ b/content/v3/repos/statuses.md
@@ -4,6 +4,9 @@ title: Statuses | GitHub API
 
 # Repo Statuses API
 
+* TOC
+{:toc}
+
 The Status API allows external services to mark commits with a success,
 failure, error, or pending `state`, which is then reflected in pull requests
 involving those commits.

--- a/content/v3/repos/watching.md
+++ b/content/v3/repos/watching.md
@@ -4,6 +4,9 @@ title: Repo Watching | GitHub API
 
 # Repo Watching API
 
+* TOC
+{:toc}
+
 We recently [changed the way watching
 works](https://github.com/blog/1204-notifications-stars) on GitHub. We hope to
 roll out many of these features in the API soon. Until then, the [Watchers

--- a/content/v3/search.md
+++ b/content/v3/search.md
@@ -4,6 +4,9 @@ title: Search | GitHub API
 
 # Search
 
+* TOC
+{:toc}
+
 This is a listing of the Search API features from API v2 that have been ported to API
 v3. There should be no changes, other than the new URL and JSON output format.
 

--- a/content/v3/users.md
+++ b/content/v3/users.md
@@ -4,6 +4,9 @@ title: Users | GitHub API
 
 # Users API
 
+* TOC
+{:toc}
+
 Many of the resources on the users API provide a shortcut for getting
 information about the currently authenticated user. If a request URL
 does not include a `:user` parameter then the response will be for the

--- a/content/v3/users/emails.md
+++ b/content/v3/users/emails.md
@@ -4,6 +4,9 @@ title: User Emails | GitHub API
 
 # User Emails API
 
+* TOC
+{:toc}
+
 Management of email addresses via the API requires that you are
 authenticated.
 

--- a/content/v3/users/followers.md
+++ b/content/v3/users/followers.md
@@ -4,6 +4,9 @@ title: User Followers | GitHub API
 
 # User Followers API
 
+* TOC
+{:toc}
+
 ## List followers of a user
 
 List a user's followers:

--- a/content/v3/users/keys.md
+++ b/content/v3/users/keys.md
@@ -4,6 +4,9 @@ title: User Public Keys | GitHub API
 
 # User Public Keys API
 
+* TOC
+{:toc}
+
 Management of public keys via the API requires that you are
 authenticated.
 


### PR DESCRIPTION
Kramdown is configured to add `<h2>` links only.  I added the TOC just under the main heading because it looked weird to see it just above the first sub heading.

I'm not crazy about how this looks.  I wonder if we can touch up the styling a bit, or maybe add some JS behavior to drop the menu down when clicking the title.

![](https://github-images.s3.amazonaws.com/skitch/OAuth_%7C_GitHub_API-20120906-103433.jpg)

/cc @github/api @github/designers 
