### PR TITLE
Fix links to media types, after the rename from mime

### DIFF
--- a/content/v3/gists/comments.md
+++ b/content/v3/gists/comments.md
@@ -9,7 +9,7 @@ title: Gist Comments | GitHub API
 
 Gist Comments leverage [these](#custom-mime-types) custom mime types.
 You can read more about the use of mime types in the API
-[here](/v3/mime/).
+[here](/v3/media/).
 
 ## List comments on a gist
 
@@ -73,7 +73,7 @@ body
 ## Custom Mime Types
 
 These are the supported mime types for gist comments. You can read more about the
-use of mime types in the API [here](/v3/mime/).
+use of mime types in the API [here](/v3/media/).
 
     application/vnd.github.VERSION.raw+json
     application/vnd.github.VERSION.text+json

--- a/content/v3/git/blobs.md
+++ b/content/v3/git/blobs.md
@@ -13,7 +13,7 @@ or `base64`.  If your data cannot be losslessly sent as a UTF-8 string,
 you can base64 encode it.
 
 Blobs leverage [these](#custom-mime-types) custom mime types. You can
-read more about the use of mime types in the API [here](/v3/mime/).
+read more about the use of mime types in the API [here](/v3/media/).
 
 ## Get a Blob
 
@@ -41,7 +41,7 @@ read more about the use of mime types in the API [here](/v3/mime/).
 ## Custom Mime Types
 
 These are the supported mime types for blobs. You can read more about the
-use of mime types in the API [here](/v3/mime/).
+use of mime types in the API [here](/v3/media/).
 
     application/json
     application/vnd.github.VERSION.raw

--- a/content/v3/issues.md
+++ b/content/v3/issues.md
@@ -8,7 +8,7 @@ title: Issues | GitHub API
 {:toc}
 
 Issues leverage [these](#custom-mime-types) custom mime types. You can
-read more about the use of mime types in the API [here](/v3/mime/).
+read more about the use of mime types in the API [here](/v3/media/).
 
 ## List your issues
 
@@ -174,7 +174,7 @@ Issue. Send an empty array (`[]`) to clear all Labels from the Issue.
 ## Custom Mime Types
 
 These are the supported mime types for issues. You can read more about the
-use of mime types in the API [here](/v3/mime/).
+use of mime types in the API [here](/v3/media/).
 
     application/vnd.github.VERSION.raw+json
     application/vnd.github.VERSION.text+json

--- a/content/v3/issues/comments.md
+++ b/content/v3/issues/comments.md
@@ -12,7 +12,7 @@ comments on issues and pull requests.
 
 Issue Comments leverage [these](#custom-mime-types) custom mime types.
 You can read more about the use of mime types in the API
-[here](/v3/mime/).
+[here](/v3/media/).
 
 ## List comments on an issue
 
@@ -77,7 +77,7 @@ body
 ## Custom Mime Types
 
 These are the supported mime types for issue comments. You can read more
-about the use of mime types in the API [here](/v3/mime/).
+about the use of mime types in the API [here](/v3/media/).
 
     application/vnd.github.VERSION.raw+json
     application/vnd.github.VERSION.text+json

--- a/content/v3/pulls.md
+++ b/content/v3/pulls.md
@@ -13,7 +13,7 @@ Comments API](/v3/issues/comments/).
 
 Pull Requests leverage [these](#custom-mime-types) custom mime types. You
 can read more about the use of mime types in the API
-[here](/v3/mime/).
+[here](/v3/media/).
 
 ## Link Relations
 
@@ -193,7 +193,7 @@ commit\_message
 ## Custom Mime Types
 
 These are the supported mime types for pull requests. You can read more about the
-use of mime types in the API [here](/v3/mime/).
+use of mime types in the API [here](/v3/media/).
 
     application/vnd.github.VERSION.raw+json
     application/vnd.github.VERSION.text+json

--- a/content/v3/pulls/comments.md
+++ b/content/v3/pulls/comments.md
@@ -14,7 +14,7 @@ Comments (which do not reference a portion of the unified diff).
 
 Pull Request Review Comments leverage [these](#custom-mime-types) custom mime
 types. You can read more about the use of mime types in the API
-[here](/v3/mime/).
+[here](/v3/media/).
 
 ## List comments on a pull request
 
@@ -117,7 +117,7 @@ body
 ## Custom Mime Types
 
 These are the supported mime types for pull request comments. You can read
-more about the use of mime types in the API [here](/v3/mime/).
+more about the use of mime types in the API [here](/v3/media/).
 
     application/vnd.github.VERSION.raw+json
     application/vnd.github.VERSION.text+json

--- a/content/v3/repos/comments.md
+++ b/content/v3/repos/comments.md
@@ -10,7 +10,7 @@ title: Repo Comments | GitHub API
 ## List commit comments for a repository
 
 Commit Comments leverage [these](#custom-mime-types) custom mime types. You can
-read more about the use of mime types in the API [here](/v3/mime/).
+read more about the use of mime types in the API [here](/v3/media/).
 
 Comments are ordered by ascending ID.
 
@@ -104,7 +104,7 @@ body
 ## Custom Mime Types
 
 These are the supported mime types for commit comments. You can read more
-about the use of mime types in the API [here](/v3/mime/).
+about the use of mime types in the API [here](/v3/media/).
 
     application/vnd.github-commitcomment.raw+json
     application/vnd.github-commitcomment.text+json

--- a/content/v3/repos/contents.md
+++ b/content/v3/repos/contents.md
@@ -8,7 +8,7 @@ title: Repo Contents | GitHub API
 {:toc}
 
 These API methods let you retrieve the contents of files within a repository as
-Base64 encoded content. See [Mime types](/v3/mime) for requesting raw or other formats.
+Base64 encoded content. See [Mime types](/v3/media/) for requesting raw or other formats.
 
 ## Get the README
 


### PR DESCRIPTION
f28c4e4 moved the location of the file, but didn't fix all of the files
that refer to it.
