### PR TITLE
Git Internals link updated to reflect new path

### DIFF
--- a/content/v3/git.md
+++ b/content/v3/git.md
@@ -20,7 +20,7 @@ Support](https://github.com/contact) if this response status persists.
 ![git db](http://git-scm.com/figures/18333fig0904-tn.png)
 
 For more information on the Git object database, please read the
-<a href="http://git-scm.com/book/ch9-0.html">Git Internals</a> chapter of
+<a href="http://git-scm.com/book/en/Git-Internals">Git Internals</a> chapter of
 the Pro Git book.
 
 As an example, if you wanted to commit a change to a file in your


### PR DESCRIPTION
git-scm.com changed the link the Git Internals chapter of the Pro Git Book.
Current link is broken, this fixes that link. 
