### PR TITLE
Swap :user for :owner for clarity

### DIFF
--- a/content/index.md
+++ b/content/index.md
@@ -34,8 +34,8 @@ The API is expected to be finalized Real Soon Now.
 
 * All `*_url` attributes move to a `_links` object.  See [Pull
   Requests](/v3/pulls/#get-a-single-pull-request) for an example.
-* The `/repos/:user/:repo/hooks/:id/test` action becomes
-  `/repos/:user/:repo/hooks/:id/tests`.
+* The `/repos/:owner/:repo/hooks/:id/test` action becomes
+  `/repos/:owner/:repo/hooks/:id/tests`.
 * The `/gists/:id/fork` action becomes `/gists/:id/forks`.
 * Gist forks/history objects become separate API calls.
 * Gist files object is not returned on Gist listings.

--- a/content/v3.md
+++ b/content/v3.md
@@ -50,7 +50,7 @@ parameter:
 $ curl -i "https://api.github.com/repos/mojombo/jekyll/issues?state=closed"
 </pre>
 
-In this example, the 'mojombo' and 'jekyll' values are provided for the `:user`
+In this example, the 'mojombo' and 'jekyll' values are provided for the `:owner`
 and `:repo` parameters in the path while `:state` is passed in the query
 string.
 

--- a/content/v3/events.md
+++ b/content/v3/events.md
@@ -25,15 +25,15 @@ All Events have the same response format:
 
 ## List repository events
 
-    GET /repos/:user/:repo/events
+    GET /repos/:owner/:repo/events
 
 ## List issue events for a repository
 
-    GET /repos/:user/:repo/issues/events
+    GET /repos/:owner/:repo/issues/events
 
 ## List public events for a network of repositories
 
-    GET /networks/:user/:repo/events
+    GET /networks/:owner/:repo/events
 
 ## List public events for an organization
 

--- a/content/v3/git/blobs.md
+++ b/content/v3/git/blobs.md
@@ -17,7 +17,7 @@ read more about the use of mime types in the API [here](/v3/media/).
 
 ## Get a Blob
 
-    GET /repos/:user/:repo/git/blobs/:sha
+    GET /repos/:owner/:repo/git/blobs/:sha
 
 ### Response
 
@@ -26,7 +26,7 @@ read more about the use of mime types in the API [here](/v3/media/).
 
 ## Create a Blob
 
-    POST /repos/:user/:repo/git/blobs
+    POST /repos/:owner/:repo/git/blobs
 
 ### Input
 
@@ -35,7 +35,7 @@ read more about the use of mime types in the API [here](/v3/media/).
 ### Response
 
 <%= headers 201,
-      :Location => "https://api.github.com/git/:user/:repo/blob/:sha" %>
+      :Location => "https://api.github.com/git/:owner/:repo/blob/:sha" %>
 <%= json :sha => "3a0f86fb8db8eea7ccbb9a95f325ddbedfb25e15" %>
 
 ## Custom Mime Types

--- a/content/v3/git/commits.md
+++ b/content/v3/git/commits.md
@@ -9,7 +9,7 @@ title: Git Commits | GitHub API
 
 ## Get a Commit
 
-    GET /repos/:user/:repo/git/commits/:sha
+    GET /repos/:owner/:repo/git/commits/:sha
 
 ### Response
 
@@ -18,7 +18,7 @@ title: Git Commits | GitHub API
 
 ## Create a Commit
 
-    POST /repos/:user/:repo/git/commits
+    POST /repos/:owner/:repo/git/commits
 
 ### Parameters
 
@@ -71,6 +71,6 @@ committer.date
 ### Response
 
 <%= headers 201,
-      :Location => "https://api.github.com/git/:user/:repo/commit/:sha" %>
+      :Location => "https://api.github.com/git/:owner/:repo/commit/:sha" %>
 <%= json :new_commit %>
 

--- a/content/v3/git/refs.md
+++ b/content/v3/git/refs.md
@@ -9,11 +9,11 @@ title: Git Refs | GitHub API
 
 ## Get a Reference
 
-    GET /repos/:user/:repo/git/refs/:ref
+    GET /repos/:owner/:repo/git/refs/:ref
 
 The `ref` in the URL must be formatted as `heads/branch`, not just `branch`. For example, the call to get the data for a branch named `skunkworkz/featureA` would be:
 
-    GET /repos/:user/:repo/git/refs/heads/skunkworkz/featureA
+    GET /repos/:owner/:repo/git/refs/heads/skunkworkz/featureA
 
 ### Response
 
@@ -22,7 +22,7 @@ The `ref` in the URL must be formatted as `heads/branch`, not just `branch`. For
 
 ## Get all References
 
-    GET /repos/:user/:repo/git/refs
+    GET /repos/:owner/:repo/git/refs
 
 This will return an array of all the references on the system, including
 things like notes and stashes if they exist on the server.  Anything in
@@ -32,7 +32,7 @@ most common.
 You can also request a sub-namespace. For example, to get all the tag
 references, you can call:
 
-    GET /repos/:user/:repo/git/refs/tags
+    GET /repos/:owner/:repo/git/refs/tags
 
 For a full refs listing, you'll get something that looks like:
 
@@ -42,7 +42,7 @@ For a full refs listing, you'll get something that looks like:
 
 ## Create a Reference
 
-    POST /repos/:user/:repo/git/refs
+    POST /repos/:owner/:repo/git/refs
 
 ### Parameters
 
@@ -65,7 +65,7 @@ sha
 
 ## Update a Reference
 
-    PATCH /repos/:user/:repo/git/refs/:ref
+    PATCH /repos/:owner/:repo/git/refs/:ref
 
 ### Parameters
 
@@ -85,12 +85,12 @@ out or setting it to `false` will make sure you're not overwriting work.
 ### Response
 
 <%= headers 200, \
-      :Location => "https://api.github.com/git/:user/:repo/commit/:sha" %>
+      :Location => "https://api.github.com/git/:owner/:repo/commit/:sha" %>
 <%= json :ref %>
 
 ## Delete a Reference
 
-    DELETE /repos/:user/:repo/git/refs/:ref
+    DELETE /repos/:owner/:repo/git/refs/:ref
 
 Example: Deleting a branch:
 

--- a/content/v3/git/tags.md
+++ b/content/v3/git/tags.md
@@ -12,7 +12,7 @@ lightweight tags.
 
 ## Get a Tag
 
-    GET /repos/:user/:repo/git/tags/:sha
+    GET /repos/:owner/:repo/git/tags/:sha
 
 ### Response
 
@@ -28,7 +28,7 @@ the `refs/tags/[tag]` reference.  If you want to create a lightweight
 tag, you simply have to create the reference - this call would be
 unnecessary.
 
-    POST /repos/:user/:repo/git/tags
+    POST /repos/:owner/:repo/git/tags
 
 ### Parameters
 
@@ -57,6 +57,6 @@ tagger.date
 ### Response
 
 <%= headers 201,
-      :Location => "https://api.github.com/repos/:user/:repo/git/tags/:sha" %>
+      :Location => "https://api.github.com/repos/:owner/:repo/git/tags/:sha" %>
 <%= json :gittag %>
 

--- a/content/v3/git/trees.md
+++ b/content/v3/git/trees.md
@@ -9,7 +9,7 @@ title: Git Trees | GitHub API
 
 ## Get a Tree
 
-    GET /repos/:user/:repo/git/trees/:sha
+    GET /repos/:owner/:repo/git/trees/:sha
 
 ### Response
 
@@ -18,7 +18,7 @@ title: Git Trees | GitHub API
 
 ## Get a Tree Recursively
 
-    GET /repos/:user/:repo/git/trees/:sha?recursive=1
+    GET /repos/:owner/:repo/git/trees/:sha?recursive=1
 
 ### Response
 
@@ -32,7 +32,7 @@ tree and a nested path modifying that tree are specified, it will
 overwrite the contents of that tree with the new path contents and write
 a new tree out.
 
-    POST /repos/:user/:repo/git/trees
+    POST /repos/:owner/:repo/git/trees
 
 ### Parameters
 
@@ -68,6 +68,6 @@ tree.content
 ### Response
 
 <%= headers 201,
-      :Location => "https://api.github.com/repos/:user/:repo/git/trees/:sha" %>
+      :Location => "https://api.github.com/repos/:owner/:repo/git/trees/:sha" %>
 <%= json :tree_new %>
 

--- a/content/v3/issues.md
+++ b/content/v3/issues.md
@@ -45,7 +45,7 @@ since
 
 ## List issues for a repository
 
-    GET /repos/:user/:repo/issues
+    GET /repos/:owner/:repo/issues
 
 ### Parameters
 
@@ -85,7 +85,7 @@ since
 
 ## Get a single issue
 
-    GET /repos/:user/:repo/issues/:number
+    GET /repos/:owner/:repo/issues/:number
 
 ### Response
 
@@ -94,7 +94,7 @@ since
 
 ## Create an issue
 
-    POST /repos/:user/:repo/issues
+    POST /repos/:owner/:repo/issues
 
 ### Input
 
@@ -132,7 +132,7 @@ issue.
 
 ## Edit an issue
 
-    PATCH /repos/:user/:repo/issues/:number
+    PATCH /repos/:owner/:repo/issues/:number
 
 ### Input
 

--- a/content/v3/issues/assignees.md
+++ b/content/v3/issues/assignees.md
@@ -12,7 +12,7 @@ title: Issue Assignees | GitHub API
 This call lists all the available assignees (owner + collaborators) to which
 issues may be assigned.
 
-    GET /repos/:user/:repo/assignees
+    GET /repos/:owner/:repo/assignees
 
 ### Response
 
@@ -23,7 +23,7 @@ issues may be assigned.
 
 You may also check to see if a particular user is an assignee for a repository.
 
-    GET /repos/:user/:repo/assignees/:assignee
+    GET /repos/:owner/:repo/assignees/:assignee
 
 ### Response
 

--- a/content/v3/issues/comments.md
+++ b/content/v3/issues/comments.md
@@ -16,7 +16,7 @@ You can read more about the use of mime types in the API
 
 ## List comments on an issue
 
-    GET /repos/:user/:repo/issues/:number/comments
+    GET /repos/:owner/:repo/issues/:number/comments
 
 ### Response
 
@@ -25,7 +25,7 @@ You can read more about the use of mime types in the API
 
 ## Get a single comment
 
-    GET /repos/:user/:repo/issues/comments/:id
+    GET /repos/:owner/:repo/issues/comments/:id
 
 ### Response
 
@@ -34,7 +34,7 @@ You can read more about the use of mime types in the API
 
 ## Create a comment
 
-    POST /repos/:user/:repo/issues/:number/comments
+    POST /repos/:owner/:repo/issues/:number/comments
 
 ### Input
 
@@ -52,7 +52,7 @@ body
 
 ## Edit a comment
 
-    PATCH /repos/:user/:repo/issues/comments/:id
+    PATCH /repos/:owner/:repo/issues/comments/:id
 
 ### Input
 
@@ -68,7 +68,7 @@ body
 
 ## Delete a comment
 
-    DELETE /repos/:user/:repo/issues/comments/:id
+    DELETE /repos/:owner/:repo/issues/comments/:id
 
 ### Response
 

--- a/content/v3/issues/events.md
+++ b/content/v3/issues/events.md
@@ -51,7 +51,7 @@ assigned
 
 ## List events for an issue
 
-    GET /repos/:user/:repo/issues/:issue_number/events
+    GET /repos/:owner/:repo/issues/:issue_number/events
 
 ### Response
 
@@ -60,7 +60,7 @@ assigned
 
 ## List events for a repository
 
-    GET /repos/:user/:repo/issues/events
+    GET /repos/:owner/:repo/issues/events
 
 ### Response
 
@@ -69,7 +69,7 @@ assigned
 
 ## Get a single event
 
-    GET /repos/:user/:repo/issues/events/:id
+    GET /repos/:owner/:repo/issues/events/:id
 
 ### Response
 

--- a/content/v3/issues/labels.md
+++ b/content/v3/issues/labels.md
@@ -9,7 +9,7 @@ title: Issue Labels | GitHub API
 
 ## List all labels for this repository
 
-    GET /repos/:user/:repo/labels
+    GET /repos/:owner/:repo/labels
 
 ### Response
 
@@ -18,7 +18,7 @@ title: Issue Labels | GitHub API
 
 ## Get a single label
 
-    GET /repos/:user/:repo/labels/:name
+    GET /repos/:owner/:repo/labels/:name
 
 ### Response
 
@@ -27,7 +27,7 @@ title: Issue Labels | GitHub API
 
 ## Create a label
 
-    POST /repos/:user/:repo/labels
+    POST /repos/:owner/:repo/labels
 
 ### Input
 
@@ -48,7 +48,7 @@ color
 
 ## Update a label
 
-    PATCH /repos/:user/:repo/labels/:name
+    PATCH /repos/:owner/:repo/labels/:name
 
 ### Input
 
@@ -67,7 +67,7 @@ color
 
 ## Delete a label
 
-    DELETE /repos/:user/:repo/labels/:name
+    DELETE /repos/:owner/:repo/labels/:name
 
 ### Response
 
@@ -75,7 +75,7 @@ color
 
 ## List labels on an issue
 
-    GET /repos/:user/:repo/issues/:number/labels
+    GET /repos/:owner/:repo/issues/:number/labels
 
 ### Response
 
@@ -84,7 +84,7 @@ color
 
 ## Add labels to an issue
 
-    POST /repos/:user/:repo/issues/:number/labels
+    POST /repos/:owner/:repo/issues/:number/labels
 
 ### Input
 
@@ -97,7 +97,7 @@ color
 
 ## Remove a label from an issue
 
-    DELETE /repos/:user/:repo/issues/:number/labels/:name
+    DELETE /repos/:owner/:repo/issues/:number/labels/:name
 
 ### Response
 
@@ -106,7 +106,7 @@ color
 
 ## Replace all labels for an issue
 
-    PUT /repos/:user/:repo/issues/:number/labels
+    PUT /repos/:owner/:repo/issues/:number/labels
 
 ### Input
 
@@ -121,7 +121,7 @@ Sending an empty array (`[]`) will remove all Labels from the Issue.
 
 ## Remove all labels from an issue
 
-    DELETE /repos/:user/:repo/issues/:number/labels
+    DELETE /repos/:owner/:repo/issues/:number/labels
 
 ### Response
 
@@ -129,7 +129,7 @@ Sending an empty array (`[]`) will remove all Labels from the Issue.
 
 ## Get labels for every issue in a milestone
 
-    GET /repos/:user/:repo/milestones/:number/labels
+    GET /repos/:owner/:repo/milestones/:number/labels
 
 ### Response
 

--- a/content/v3/issues/milestones.md
+++ b/content/v3/issues/milestones.md
@@ -9,7 +9,7 @@ title: Issue Milestones | GitHub API
 
 ## List milestones for a repository
 
-    GET /repos/:user/:repo/milestones
+    GET /repos/:owner/:repo/milestones
 
 ### Parameters
 
@@ -29,7 +29,7 @@ direction
 
 ## Get a single milestone
 
-    GET /repos/:user/:repo/milestones/:number
+    GET /repos/:owner/:repo/milestones/:number
 
 ### Response
 
@@ -38,7 +38,7 @@ direction
 
 ## Create a milestone
 
-    POST /repos/:user/:repo/milestones
+    POST /repos/:owner/:repo/milestones
 
 ### Input
 
@@ -70,7 +70,7 @@ due\_on
 
 ## Update a milestone
 
-    PATCH /repos/:user/:repo/milestones/:number
+    PATCH /repos/:owner/:repo/milestones/:number
 
 ### Input
 
@@ -103,7 +103,7 @@ due\_on
 
 ## Delete a milestone
 
-    DELETE /repos/:user/:repo/milestones/:number
+    DELETE /repos/:owner/:repo/milestones/:number
 
 ### Response
 

--- a/content/v3/orgs/teams.md
+++ b/content/v3/orgs/teams.md
@@ -176,7 +176,7 @@ NOTE: This does not delete the user, it just remove them from the team.
 
 ## Get team repo
 
-    GET /teams/:id/repos/:user/:repo
+    GET /teams/:id/repos/:owner/:repo
 
 ### Response if repo is managed by this team
 
@@ -193,7 +193,7 @@ owner of the org that the team is associated with.  Also, the repo must
 be owned by the organization, or a direct form of a repo owned by the
 organization.
 
-    PUT /teams/:id/repos/:user/:repo
+    PUT /teams/:id/repos/:owner/:repo
 
 ### Response
 
@@ -217,7 +217,7 @@ In order to remove a repo from a team, the authenticated user must be an
 owner of the org that the team is associated with.
 NOTE: This does not delete the repo, it just removes it from the team.
 
-    DELETE /teams/:id/repos/:user/:repo
+    DELETE /teams/:id/repos/:owner/:repo
 
 ### Response
 

--- a/content/v3/pulls.md
+++ b/content/v3/pulls.md
@@ -33,7 +33,7 @@ Pull Requests have these possible link relations:
 
 ## List pull requests
 
-    GET /repos/:user/:repo/pulls
+    GET /repos/:owner/:repo/pulls
 
 ### Parameters
 
@@ -48,7 +48,7 @@ is `open`.
 
 ## Get a single pull request
 
-    GET /repos/:user/:repo/pulls/:number
+    GET /repos/:owner/:repo/pulls/:number
 
 ### Response
 
@@ -57,7 +57,7 @@ is `open`.
 
 ## Create a pull request
 
-    POST /repos/:user/:repo/pulls
+    POST /repos/:owner/:repo/pulls
 
 ### Input
 
@@ -108,7 +108,7 @@ Pull Request.
 
 ## Update a pull request
 
-    PATCH /repos/:user/:repo/pulls/:number
+    PATCH /repos/:owner/:repo/pulls/:number
 
 ### Input
 
@@ -135,7 +135,7 @@ state
 
 ## List commits on a pull request
 
-    GET /repos/:user/:repo/pulls/:number/commits
+    GET /repos/:owner/:repo/pulls/:number/commits
 
 ### Response
 
@@ -144,7 +144,7 @@ state
 
 ## List pull requests files
 
-    GET /repos/:user/:repo/pulls/:number/files
+    GET /repos/:owner/:repo/pulls/:number/files
 
 ### Response
 
@@ -153,7 +153,7 @@ state
 
 ## Get if a pull request has been merged
 
-    GET /repos/:user/:repo/pulls/:number/merge
+    GET /repos/:owner/:repo/pulls/:number/merge
 
 ### Response if pull request has been merged
 
@@ -165,7 +165,7 @@ state
 
 ## Merge a pull request (Merge Button&trade;)
 
-    PUT /repos/:user/:repo/pulls/:number/merge
+    PUT /repos/:owner/:repo/pulls/:number/merge
 
 ### Input
 

--- a/content/v3/pulls/comments.md
+++ b/content/v3/pulls/comments.md
@@ -18,7 +18,7 @@ types. You can read more about the use of mime types in the API
 
 ## List comments on a pull request
 
-    GET /repos/:user/:repo/pulls/:number/comments
+    GET /repos/:owner/:repo/pulls/:number/comments
 
 ### Response
 
@@ -27,7 +27,7 @@ types. You can read more about the use of mime types in the API
 
 ## Get a single comment
 
-    GET /repos/:user/:repo/pulls/comments/:number
+    GET /repos/:owner/:repo/pulls/comments/:number
 
 ### Response
 
@@ -36,7 +36,7 @@ types. You can read more about the use of mime types in the API
 
 ## Create a comment
 
-    POST /repos/:user/:repo/pulls/:number/comments
+    POST /repos/:owner/:repo/pulls/:number/comments
 
 ### Input
 
@@ -83,12 +83,12 @@ in_reply_to
 
 <%= headers 201,
       :Location =>
-"https://api.github.com/repos/:user/:repo/pulls/comments/1" %>
+"https://api.github.com/repos/:owner/:repo/pulls/comments/1" %>
 <%= json :pull_comment %>
 
 ## Edit a comment
 
-    PATCH /repos/:user/:repo/pulls/comments/:number
+    PATCH /repos/:owner/:repo/pulls/comments/:number
 
 ### Input
 
@@ -108,7 +108,7 @@ body
 
 ## Delete a comment
 
-    DELETE /repos/:user/:repo/pulls/comments/:number
+    DELETE /repos/:owner/:repo/pulls/comments/:number
 
 ### Response
 

--- a/content/v3/repos.md
+++ b/content/v3/repos.md
@@ -120,7 +120,7 @@ organization.
 
 ## Get
 
-    GET /repos/:user/:repo
+    GET /repos/:owner/:repo
 
 ### Response
 
@@ -129,7 +129,7 @@ organization.
 
 ## Edit
 
-    PATCH /repos/:user/:repo
+    PATCH /repos/:owner/:repo
 
 ### Input
 
@@ -175,7 +175,7 @@ repository, `false` to disable them. Default is `true`.
 
 ## List contributors
 
-    GET /repos/:user/:repo/contributors
+    GET /repos/:owner/:repo/contributors
 
 ### Parameters
 
@@ -192,7 +192,7 @@ in results.
 
 List languages for the specified repository. The value on the right of a language is the number of bytes of code written in that language.
 
-    GET /repos/:user/:repo/languages
+    GET /repos/:owner/:repo/languages
 
 ### Response
 
@@ -204,7 +204,7 @@ List languages for the specified repository. The value on the right of a languag
 
 ## List Teams
 
-    GET /repos/:user/:repo/teams
+    GET /repos/:owner/:repo/teams
 
 ### Response
 
@@ -213,7 +213,7 @@ List languages for the specified repository. The value on the right of a languag
 
 ## List Tags
 
-    GET /repos/:user/:repo/tags
+    GET /repos/:owner/:repo/tags
 
 ### Response
 
@@ -222,7 +222,7 @@ List languages for the specified repository. The value on the right of a languag
 
 ## List Branches
 
-    GET /repos/:user/:repo/branches
+    GET /repos/:owner/:repo/branches
 
 ### Response
 
@@ -231,7 +231,7 @@ List languages for the specified repository. The value on the right of a languag
 
 ## Get Branch
 
-    GET /repos/:user/:repo/branches/:branch
+    GET /repos/:owner/:repo/branches/:branch
 
 ### Response
 
@@ -243,7 +243,7 @@ List languages for the specified repository. The value on the right of a languag
 Deleting a repository requires admin access.  If OAuth is used, the
 `delete_repo` scope is required.
 
-    DELETE /repos/:user/:repo
+    DELETE /repos/:owner/:repo
 
 ### Response
 

--- a/content/v3/repos/collaborators.md
+++ b/content/v3/repos/collaborators.md
@@ -9,7 +9,7 @@ title: Repo Collaborators | GitHub API
 
 ## List
 
-    GET /repos/:user/:repo/collaborators
+    GET /repos/:owner/:repo/collaborators
 
 ### Response
 
@@ -18,7 +18,7 @@ title: Repo Collaborators | GitHub API
 
 ## Get
 
-    GET /repos/:user/:repo/collaborators/:user
+    GET /repos/:owner/:repo/collaborators/:user
 
 ### Response if user is a collaborator
 
@@ -30,7 +30,7 @@ title: Repo Collaborators | GitHub API
 
 ## Add collaborator
 
-    PUT /repos/:user/:repo/collaborators/:user
+    PUT /repos/:owner/:repo/collaborators/:user
 
 ### Response
 
@@ -38,7 +38,7 @@ title: Repo Collaborators | GitHub API
 
 ## Remove collaborator
 
-    DELETE /repos/:user/:repo/collaborators/:user
+    DELETE /repos/:owner/:repo/collaborators/:user
 
 ### Response
 

--- a/content/v3/repos/comments.md
+++ b/content/v3/repos/comments.md
@@ -14,7 +14,7 @@ read more about the use of mime types in the API [here](/v3/media/).
 
 Comments are ordered by ascending ID.
 
-    GET /repos/:user/:repo/comments
+    GET /repos/:owner/:repo/comments
 
 ### Response
 
@@ -23,7 +23,7 @@ Comments are ordered by ascending ID.
 
 ## List comments for a single commit
 
-    GET /repos/:user/:repo/commits/:sha/comments
+    GET /repos/:owner/:repo/commits/:sha/comments
 
 ### Response
 
@@ -32,7 +32,7 @@ Comments are ordered by ascending ID.
 
 ## Create a commit comment
 
-    POST /repos/:user/:repo/commits/:sha/comments
+    POST /repos/:owner/:repo/commits/:sha/comments
 
 ### Input
 
@@ -66,7 +66,7 @@ line
 
 ## Get a single commit comment
 
-    GET /repos/:user/:repo/comments/:id
+    GET /repos/:owner/:repo/comments/:id
 
 ### Response
 
@@ -75,7 +75,7 @@ line
 
 ## Update a commit comment
 
-    PATCH /repos/:user/:repo/comments/:id
+    PATCH /repos/:owner/:repo/comments/:id
 
 ### Input
 
@@ -95,7 +95,7 @@ body
 
 ## Delete a commit comment
 
-    DELETE /repos/:user/:repo/comments/:id
+    DELETE /repos/:owner/:repo/comments/:id
 
 ### Response
 

--- a/content/v3/repos/commits.md
+++ b/content/v3/repos/commits.md
@@ -11,7 +11,7 @@ The Repo Commits API supports listing, viewing, and comparing commits in a repos
 
 ## List commits on a repository
 
-    GET /repos/:user/:repo/commits
+    GET /repos/:owner/:repo/commits
 
 _A special note on pagination:_ Due to the way Git works, commits are paginated
 based on SHA instead of page number. Please follow the link headers as outlined
@@ -44,7 +44,7 @@ until
 
 ## Get a single commit
 
-    GET /repos/:user/:repo/commits/:sha
+    GET /repos/:owner/:repo/commits/:sha
 
 ### Response
 
@@ -55,7 +55,7 @@ Note: Diffs with binary data will have no 'patch' property.
 
 ## Compare two commits
 
-    GET /repos/:user/:repo/compare/:base...:head
+    GET /repos/:owner/:repo/compare/:base...:head
 
 ### Response
 

--- a/content/v3/repos/contents.md
+++ b/content/v3/repos/contents.md
@@ -14,7 +14,7 @@ Base64 encoded content. See [Mime types](/v3/media/) for requesting raw or other
 
 This method returns the preferred README for a repository.
 
-    GET /repos/:user/:repo/readme
+    GET /repos/:owner/:repo/readme
 
 ### Parameters
 
@@ -30,7 +30,7 @@ ref
 
 This method returns the contents of any file or directory in a repository.
 
-    GET /repos/:user/:repo/contents/:path
+    GET /repos/:owner/:repo/contents/:path
 
 ### Parameters
 
@@ -54,7 +54,7 @@ to make a second `GET` request.
 
 *Note*: For private repositories, these links are temporary and expire quickly.
 
-    GET /repos/:user/:repo/:archive_format/:ref
+    GET /repos/:owner/:repo/:archive_format/:ref
 
 ### Parameters
 

--- a/content/v3/repos/downloads.md
+++ b/content/v3/repos/downloads.md
@@ -13,7 +13,7 @@ instead.
 
 ## List downloads for a repository
 
-    GET /repos/:user/:repo/downloads
+    GET /repos/:owner/:repo/downloads
 
 ### Response
 
@@ -22,7 +22,7 @@ instead.
 
 ## Get a single download
 
-    GET /repos/:user/:repo/downloads/:id
+    GET /repos/:owner/:repo/downloads/:id
 
 ### Response
 
@@ -34,7 +34,7 @@ instead.
 Creating a new download is a two step process. You must first create a
 new download resource.
 
-    POST /repos/:user/:repo/downloads
+    POST /repos/:owner/:repo/downloads
 
 ### Input
 
@@ -121,7 +121,7 @@ be found [here](http://docs.amazonwebservices.com/AmazonS3/latest/API/).
 
 ## Delete a download
 
-    DELETE /repos/:user/:repo/downloads/:id
+    DELETE /repos/:owner/:repo/downloads/:id
 
 ### Response
 

--- a/content/v3/repos/forks.md
+++ b/content/v3/repos/forks.md
@@ -9,7 +9,7 @@ title: Repo Forks | GitHub API
 
 ## List forks
 
-    GET /repos/:user/:repo/forks
+    GET /repos/:owner/:repo/forks
 
 ### Parameters
 
@@ -25,7 +25,7 @@ sort
 
 Create a fork for the authenticated user.
 
-    POST /repos/:user/:repo/forks
+    POST /repos/:owner/:repo/forks
 
 ### Parameters
 

--- a/content/v3/repos/hooks.md
+++ b/content/v3/repos/hooks.md
@@ -42,7 +42,7 @@ part of the open source [github-services](https://github.com/github/github-servi
 
 ## List
 
-    GET /repos/:user/:repo/hooks
+    GET /repos/:owner/:repo/hooks
 
 ### Response
 
@@ -51,7 +51,7 @@ part of the open source [github-services](https://github.com/github/github-servi
 
 ## Get single hook
 
-    GET /repos/:user/:repo/hooks/:id
+    GET /repos/:owner/:repo/hooks/:id
 
 ### Response
 
@@ -60,7 +60,7 @@ part of the open source [github-services](https://github.com/github/github-servi
 
 ## Create a hook
 
-    POST /repos/:user/:repo/hooks
+    POST /repos/:owner/:repo/hooks
 
 ### Input
 
@@ -99,7 +99,7 @@ triggered on pushes.
 
 ### Edit a hook
 
-    PATCH /repos/:user/:repo/hooks/:id
+    PATCH /repos/:owner/:repo/hooks/:id
 
 ### Input
 
@@ -152,7 +152,7 @@ triggered on pushes.
 This will trigger the hook with the latest push to the current
 repository.
 
-    POST /repos/:user/:repo/hooks/:id/test
+    POST /repos/:owner/:repo/hooks/:id/test
 
 ### Response
 
@@ -160,7 +160,7 @@ repository.
 
 ## Delete a hook
 
-    DELETE /repos/:user/:repo/hooks/:id
+    DELETE /repos/:owner/:repo/hooks/:id
 
 ### Response
 
@@ -170,7 +170,7 @@ repository.
 
 GitHub can also serve as a [PubSubHubbub][pubsub] hub for all repositories.  PSHB is a simple publish/subscribe protocol that lets servers register to receive updates when a topic is updated.  The updates are sent with an HTTP POST request to a callback URL.  Topic URLs for a GitHub repository's pushes are in this format:
 
-    https://github.com/:user/:repo/events/:event
+    https://github.com/:owner/:repo/events/:event
 
 The event can be any Event string that is listed at the top of this
 document.
@@ -181,7 +181,7 @@ POST.  You can also specify to receive the raw JSON body with either an
 `Accept` header, or a `.json` extension.
 
     Accept: application/json
-    https://github.com/:user/:repo/events/push.json
+    https://github.com/:owner/:repo/events/push.json
 
 Callback URLs can use either the `http://` protocol, or `github://`.
 `github://` callbacks specify a GitHub service.
@@ -200,7 +200,7 @@ successful request with curl looks like:
     curl -u "user" -i \
       https://api.github.com/hub \
       -F "hub.mode=subscribe" \
-      -F "hub.topic=https://github.com/:user/:repo/events/push" \
+      -F "hub.topic=https://github.com/:owner/:repo/events/push" \
       -F "hub.callback=http://postbin.org/123"
 
 PubSubHubbub requests can be sent multiple times.  If the hook already
@@ -213,7 +213,7 @@ exists, it will be modified according to the request.
 
 `hub.topic`
 : _Required_ **string** - The URI of the GitHub repository to subscribe
-to.  The path must be in the format of `/:user/:repo/events/:event`.
+to.  The path must be in the format of `/:owner/:repo/events/:event`.
 
 `hub.callback`
 : _Required_ **string** - The URI to receive the updates to the topic.

--- a/content/v3/repos/keys.md
+++ b/content/v3/repos/keys.md
@@ -9,7 +9,7 @@ title: Repo Deploy Keys | GitHub API
 
 ## List
 
-    GET /repos/:user/:repo/keys
+    GET /repos/:owner/:repo/keys
 
 ### Response
 
@@ -18,7 +18,7 @@ title: Repo Deploy Keys | GitHub API
 
 ## Get
 
-    GET /repos/:user/:repo/keys/:id
+    GET /repos/:owner/:repo/keys/:id
 
 ### Response
 
@@ -27,7 +27,7 @@ title: Repo Deploy Keys | GitHub API
 
 ## Create
 
-    POST /repos/:user/:repo/keys
+    POST /repos/:owner/:repo/keys
 
 ### Input
 
@@ -40,7 +40,7 @@ title: Repo Deploy Keys | GitHub API
 
 ## Edit
 
-    PATCH /repos/:user/:repo/keys/:id
+    PATCH /repos/:owner/:repo/keys/:id
 
 ### Input
 
@@ -53,7 +53,7 @@ title: Repo Deploy Keys | GitHub API
 
 ## Delete
 
-    DELETE /repos/:user/:repo/keys/:id
+    DELETE /repos/:owner/:repo/keys/:id
 
 ### Response
 

--- a/content/v3/repos/merging.md
+++ b/content/v3/repos/merging.md
@@ -17,7 +17,7 @@ The authenticated user will be the author of any merges done through this endpoi
 
 ## Perform a merge
 
-    POST /repos/:user/:repo/merges
+    POST /repos/:owner/:repo/merges
 
 ### Input
 

--- a/content/v3/repos/starring.md
+++ b/content/v3/repos/starring.md
@@ -22,10 +22,10 @@ more.
 
 ## List Stargazers
 
-    GET /repos/:user/:repo/stargazers
+    GET /repos/:owner/:repo/stargazers
 
     # Legacy, using github.beta media type.
-    GET /repos/:user/:repo/watchers
+    GET /repos/:owner/:repo/watchers
 
 ### Response
 
@@ -57,10 +57,10 @@ List repositories being watched by the authenticated user.
 
 Requires for the user to be authenticated.
 
-    GET /user/starred/:user/:repo
+    GET /user/starred/:owner/:repo
 
     # Legacy, using github.beta media type.
-    GET /user/watched/:user/:repo
+    GET /user/watched/:owner/:repo
 
 ### Response if this repository is watched by you
 
@@ -74,10 +74,10 @@ Requires for the user to be authenticated.
 
 Requires for the user to be authenticated.
 
-    PUT /user/starred/:user/:repo
+    PUT /user/starred/:owner/:repo
 
     # Legacy, using github.beta media type.
-    PUT /user/watched/:user/:repo
+    PUT /user/watched/:owner/:repo
 
 ### Response
 
@@ -87,10 +87,10 @@ Requires for the user to be authenticated.
 
 Requires for the user to be authenticated.
 
-    DELETE /user/starred/:user/:repo
+    DELETE /user/starred/:owner/:repo
 
     # Legacy, using github.beta media type.
-    DELETE /user/watched/:user/:repo
+    DELETE /user/watched/:owner/:repo
 
 ### Response
 

--- a/content/v3/repos/statuses.md
+++ b/content/v3/repos/statuses.md
@@ -27,7 +27,7 @@ access to Statuses **without** also granting access to repo code, while the
 
 ## List Statuses for a specific SHA
 
-    GET /repos/:user/:repo/statuses/:sha
+    GET /repos/:owner/:repo/statuses/:sha
 
 ### Parameters
 
@@ -41,7 +41,7 @@ sha
 
 ## Create a Status
 
-    POST /repos/:user/:repo/statuses/:sha
+    POST /repos/:owner/:repo/statuses/:sha
 
 ### Parameters
 

--- a/content/v3/repos/watching.md
+++ b/content/v3/repos/watching.md
@@ -19,7 +19,7 @@ API, the Watching API will use the below "subscription" endpoints.  Check the
 
 ## List watchers
 
-    GET /repos/:user/:repo/subscribers
+    GET /repos/:owner/:repo/subscribers
 
 ### Response
 
@@ -45,7 +45,7 @@ List repositories being watched by the authenticated user.
 
 Requires for the user to be authenticated.
 
-    GET /user/subscriptions/:user/:repo
+    GET /user/subscriptions/:owner/:repo
 
 ### Response if this repository is watched by you
 
@@ -59,7 +59,7 @@ Requires for the user to be authenticated.
 
 Requires for the user to be authenticated.
 
-    PUT /user/subscriptions/:user/:repo
+    PUT /user/subscriptions/:owner/:repo
 
 ### Response
 
@@ -69,7 +69,7 @@ Requires for the user to be authenticated.
 
 Requires for the user to be authenticated.
 
-    DELETE /user/subscriptions/:user/:repo
+    DELETE /user/subscriptions/:owner/:repo
 
 ### Response
 


### PR DESCRIPTION
I've seen a number of new API users get tripped up on the :user
parameter when they're looking up a repository that belongs to an org.
This changes all the :user/:repo pairs in the docs to :owner/:repo to be
a bit clearer.
