### PR TITLE
Provide a better example of a JSON request

### DIFF
--- a/content/v3.md
+++ b/content/v3.md
@@ -18,20 +18,23 @@ domain (or through `yourdomain.com/api/v3/` for enterprise).  All data is
 sent and received as JSON.
 
 <pre class="terminal">
-$ curl -i https://api.github.com
+$ curl -i https://api.github.com/users/octocat/orgs
 
-HTTP/1.1 302 Found
-Server: nginx/1.0.12
-Date: Mon, 20 Feb 2012 11:15:49 GMT
-Content-Type: text/html;charset=utf-8
+HTTP/1.1 200 OK
+Server: nginx
+Date: Fri, 12 Oct 2012 23:33:14 GMT
+Content-Type: application/json; charset=utf-8
 Connection: keep-alive
-Status: 302 Found
+Status: 200 OK
+ETag: "a00049ba79152d03380c34652f2cb612"
 X-RateLimit-Limit: 5000
-ETag: "d41d8cd98f00b204e9800998ecf8427e"
-Location: http://developer.github.com
-X-RateLimit-Remaining: 4999
-Content-Length: 0
+X-GitHub-Media-Type: github.beta
+X-RateLimit-Remaining: 4987
+Content-Length: 5
+Cache-Control: max-age=0, private, must-revalidate
+X-Content-Type-Options: nosniff
 
+[]
 </pre>
 
 Blank fields are included as `null` instead of being omitted.


### PR DESCRIPTION
The example we use on the first page of our API docs seems a bit off. The preceding paragraph talks about how all requests send and receive JSON data, but:

![](http://content.screencast.com/users/haacked/folders/Jing/media/6131cac3-cd74-45ef-a7b7-3fdc85dbf29c/2012-10-12_1627.png)

Also, the response is a 302. I think the point of this example is to be short and show JSON being returned. I chose a request that returns an empty array since almost any other request gives you this giant blob of JSON. That would suck as an example too.
