### PR TITLE
Fixed wrong fieldname in JSON example

### DIFF
--- a/content/v3/repos/statuses.md
+++ b/content/v3/repos/statuses.md
@@ -63,8 +63,8 @@ description
 
 <%= json \
   :state         => "success",
-  :description   => "The build succeeded!",
-  :homepage      => "https://example.com/build/status"
+  :target_url      => "https://example.com/build/status",
+  :description   => "The build succeeded!"
 %>
 
 ### Response


### PR DESCRIPTION
Fixed the JSON example I provided earlier (sorry!).
Also re-ordered JSON elements to match the order
the fields are presented in the docs.
