### PR TITLE
Add required permissions for repo keys

### DIFF
--- a/content/v3/repos/keys.md
+++ b/content/v3/repos/keys.md
@@ -7,7 +7,7 @@ title: Repo Deploy Keys | GitHub API
 * TOC
 {:toc}
 
-The authorization used must have repo:keys scope added to it
+Permissions required: repo:keys
 
 ## List
 


### PR DESCRIPTION
There is no documentation on what authorisation scope is required when accessing the api. Took me a while to figure it out so though I would add something to clear it up.
