### PR TITLE
Fix wording for defining 'users followed by a user'

### DIFF
--- a/content/v3/users/followers.md
+++ b/content/v3/users/followers.md
@@ -22,7 +22,7 @@ List the authenticated user's followers:
 <%= headers 200, :pagination => true %>
 <%= json(:user) { |h| [h] } %>
 
-## List users following another user
+## List users followed by another user
 
 List who a user is following:
 


### PR DESCRIPTION
tl;dr -- Fixing a small error in user/followers section headings

Currently, the first two [users/followers section](http://developer.github.com/v3/users/followers/) headings are: "List followers of a user" and "List users following another user" (both have the same meaning, which is wrong since they explain different resources).

The [second one](http://developer.github.com/v3/users/followers/#list-users-following-another-user) actually explains the API call to fetch the list of _users that the specified user follows_ (`/following`), not the _list of users following another user_ (`/followers`), so the heading needed rewording.
