### PR TITLE
Link to API key management pages from homepage

### DIFF
--- a/content/index.md
+++ b/content/index.md
@@ -13,6 +13,8 @@ For the new API v3, start browsing the resources on the right >>
 View the [API Changelog](#changes) for information on existing and
 planned changes to the API.
 
+To get started, [create an API key](https://github.com/settings/applications/new) or [manage your existing API keys](https://github.com/settings/applications).
+
 ## Current Version
 
     Accept: application/vnd.github.beta+json


### PR DESCRIPTION
It took me quite a while to figure out how to edit my existing
API keys. Linking to those pages from the homepage of
http://developer.github.com/ seems like a sensible improvement.
