### PR TITLE
Fix 404 event url

### DIFF
--- a/content/v3.md
+++ b/content/v3.md
@@ -226,7 +226,7 @@ Requests that return multiple items will be paginated to 30 items by
 default.  You can specify further pages with the `?page` parameter. For some
 resources, you can also set a custom page size up to 100 with the `?per_page` parameter.
 Note that for technical reasons not all endpoints respect the `?per_page` parameter,
-see [events](http://developer.github.com/v3/events/) for example.
+see [events](http://developer.github.com/v3/activity/events/) for example.
 
 <pre class="terminal">
 $ curl https://api.github.com/user/repos?page=2&per_page=100


### PR DESCRIPTION
The main v3 page has a reference to the event URL that goes to a 404.
