### PR TITLE
Note "forking to an organization" changes in the docs

### DIFF
--- a/content/v3/repos/forks.md
+++ b/content/v3/repos/forks.md
@@ -27,7 +27,10 @@ Create a fork for the authenticated user.
 
     POST /repos/:owner/:repo/forks
 
-### Parameters
+One can either use the `organization` parameter or POST a JSON document with
+the field `organization`
+
+### Input/Parameters
 
 organization
 : _Optional_ **String** - Organization login. The repository will be


### PR DESCRIPTION
I changed the heading to Input/Parameters since it's the same data for either.
There's no need to specify both in separate sections and the note above it
should serve to explain that.
