### PR TITLE
Facebook API redirects to Facebook Login guide

### DIFF
--- a/content/v3/libraries.md
+++ b/content/v3/libraries.md
@@ -48,12 +48,12 @@ The [GitHub Java API](https://github.com/eclipse/egit-github/tree/master/org.ecl
 is part of the [GitHub Mylyn Connector](https://github.com/eclipse/egit-github) and aims to support the entire
 GitHub v3 API.  Builds are available in [Maven Central](http://search.maven.org/#search%7Cga%7C1%7Ca%3A%22org.eclipse.egit.github.core%22).
 
-## Javascript
+## JavaScript
 
 * [Node-GitHub][ajaxorg-node-github]
 * [NodeJS GitHub library][octonode]
 * [gh3 client-side API v3 wrapper][gh3]
-* [GitHub.js wrapper around the Github API][github]
+* [GitHub.js wrapper around the GitHub API][github]
 
 [ajaxorg-node-github]: https://github.com/ajaxorg/node-github
 [octonode]: https://github.com/pksunkara/octonode
@@ -69,10 +69,10 @@ GitHub v3 API.  Builds are available in [Maven Central](http://search.maven.org/
 ## Perl
 
 * [Pithub][pithub-github] ([CPAN][pithub-cpan])
-* [Net::Github][net-github-github] ([CPAN][net-github-cpan])
+* [Net::GitHub][net-github-github] ([CPAN][net-github-cpan])
 
 [net-github-github]: https://github.com/fayland/perl-net-github
-[net-github-cpan]: http://search.cpan.org/~fayland/Net-GitHub-0.30/lib/Net/GitHub.pm
+[net-github-cpan]: http://search.cpan.org/dist/Net-GitHub/
 [pithub-github]: https://github.com/plu/Pithub
 [pithub-cpan]: http://metacpan.org/module/Pithub
 
@@ -101,7 +101,7 @@ GitHub v3 API.  Builds are available in [Maven Central](http://search.maven.org/
 [libsaas]: https://github.com/ducksboard/libsaas
 [github3py]: https://github.com/sigmavirus24/github3.py
 [sanction]: https://github.com/demianbrecht/sanction
-[agithub]: https://github.com/jpaugh64/agithub "Agnostic Github"
+[agithub]: https://github.com/jpaugh64/agithub "Agnostic GitHub"
 [githubpy]: https://github.com/michaelliao/githubpy
 
 ## Ruby

--- a/content/v3/oauth.md
+++ b/content/v3/oauth.md
@@ -275,12 +275,12 @@ It can be a little tricky to get started with OAuth. Here are a few
 links that might be of help:
 
 * [OAuth 2 spec](http://tools.ietf.org/html/draft-ietf-oauth-v2-07)
-* [Facebook API](http://developers.facebook.com/docs/authentication/)
+* [Facebook Login API](http://developers.facebook.com/docs/technical-guides/login/)
 * [Ruby OAuth2 lib](https://github.com/intridea/oauth2)
-* [simple ruby/sinatra example](https://gist.github.com/9fd1a6199da0465ec87c)
-* [simple python example](https://gist.github.com/e3fbd47fbb7ee3c626bb) using [python-oauth2](http://github.com/dgouldin/python-oauth2)
-* [Ruby OmniAuth example](http://github.com/intridea/omniauth)
-* [Ruby Sinatra extension](http://github.com/atmos/sinatra_auth_github)
-* [Ruby Warden strategy](http://github.com/atmos/warden-github)
+* [Simple Ruby/Sinatra example](https://gist.github.com/9fd1a6199da0465ec87c)
+* [Simple Python example](https://gist.github.com/e3fbd47fbb7ee3c626bb) using [python-oauth2](https://github.com/dgouldin/python-oauth2)
+* [Ruby OmniAuth example](https://github.com/intridea/omniauth)
+* [Ruby Sinatra extension](https://github.com/atmos/sinatra_auth_github)
+* [Ruby Warden strategy](https://github.com/atmos/warden-github)
 
 [app-listing]: https://github.com/settings/applications


### PR DESCRIPTION
URL needs to be updated along with title so as to not land the
user on a page they think is wrongly linked/called. Pointing
to their technical guides might also be warmer than a straight
drop into the API specs.

Also spruces up some of those GitHub links in OAuth since all
are on the SSL flavour.

That Net::Github CPAN link also moved house.
