### PR TITLE
Split the missing head/missing base response into two separate parts

### DIFF
--- a/content/v3/repos/merging.md
+++ b/content/v3/repos/merging.md
@@ -51,8 +51,12 @@ If omitted, a default message will be used.
 <%= headers 409 %>
 <%= json({ :message => "Merge Conflict" }) %>
 
-### Missing base or head response
+### Missing base response
 
 <%= headers 404 %>
 <%= json(:message => "Base does not exist") %>
+
+### Missing head response
+
+<%= headers 404 %>
 <%= json(:message => "Head does not exist") %>


### PR DESCRIPTION
Current documentation shows the [missing head/missing base response](http://developer.github.com/v3/repos/merging/) as a single section however the CSS boxes don't line up and appear separated.

![css corners not lining up](http://share.jacobbednarz.com/repo-merging-github-api-20121230-083245.png)

This may be easier to just create a new css class that can be used for multiple responses under a single header however I thought seeing how they are still different, probably best to separate them.

With new changes, output should look like this:
![new-missing-base/header-response](http://share.jacobbednarz.com/changed-merging-api-20121230-083933.png)
