### PR TITLE
A NAME in URL was causing sidebar menus to collapse on refresh

### DIFF
--- a/static/shared/js/documentation.js
+++ b/static/shared/js/documentation.js
@@ -11,7 +11,8 @@ $(function() {
     if(docUrl){
       $('#js-sidebar .js-topic a').each(function(){
         var url = $(this).attr('href').toString()
-        if(url.indexOf(docUrl[1]) >= 0 && url.length == docUrl[1].length){
+        var cleanDocUrl = docUrl[1].split('#')[0]
+        if(url.indexOf(cleanDocUrl) >= 0 && url.length == cleanDocUrl.length){
           $(this).parent('li').addClass('disable')
           var parentTopic = $(this).parentsUntil('div.sidebar-module > ul').last()
           parentTopic.addClass('js-current')


### PR DESCRIPTION
Using an A NAME tag to reference a link on the same page was causing
the sidebar menu options to collapse on refresh.  This change takes the
provided docUrl variable in the documentation.js javascript and strips
all characters after the "#" sign.
