### PR TITLE
Add missing team_add event to documentation

### DIFF
--- a/content/v3/repos/hooks.md
+++ b/content/v3/repos/hooks.md
@@ -30,6 +30,7 @@ request is tracking).
 * `member` - Any time a User is added as a collaborator to a
   non-Organization Repository.
 * `public` - Any time a Repository changes from private to public.
+* `team_add` - Any time a team is added or modified on a Repository.
 * `status` - Any time a Repository has a status update from the API
 
 The payloads for all of the hooks mirror [the payloads for the Event


### PR DESCRIPTION
This event is listed on [the events page](http://developer.github.com/v3/activity/events/types/#teamaddevent) but was not listed in the documentation. I think I correctly described what the event does, but I'm not certain.
