### PR TITLE
Updated documentation on trees

### DIFF
--- a/content/v3/git/trees.md
+++ b/content/v3/git/trees.md
@@ -37,7 +37,7 @@ a new tree out.
 ### Parameters
 
 base_tree
-: optional _String_ of the SHA1 of the tree you want to update with new data
+: optional _String_ of the SHA1 of the tree you want to update with new data. If you don't set this it the commit will be created on top of everything, however, it will only contain your change, the rest of your files will show up as deleted.
 
 tree
 : _Array_ of _Hash_ objects (of `path`, `mode`, `type` and `sha`) specifying a tree structure


### PR DESCRIPTION
Had this issue while talking to the API.

If you don't have the base_tree, it will put a commit on top, with the correct parent, but all the rest of your files will be deleted.
