### PR TITLE
Preference for IANA special case domains in examples

### DIFF
--- a/content/v3.md
+++ b/content/v3.md
@@ -332,7 +332,7 @@ you if there are problems.
 
 ## Conditional requests
 
-Most responses return `Last-Modified` and `Etag` headers. You can use the values
+Most responses return `Last-Modified` and `ETag` headers. You can use the values
 of these headers to make subsequent requests to those resources using the
 `If-Modified-Since` and `If-None-Match` headers, respectively. If the resource
 has not changed, the server will return a `304 Not Modified`. Also note: making
@@ -378,9 +378,9 @@ you can read the [CORS W3C working draft](http://www.w3.org/TR/cors), or
 HTML 5 Security Guide.
 
 Here's a sample request sent from a browser hitting
-`http://some-site.com`:
+`http://example.com`:
 
-    $ curl -i https://api.github.com -H "Origin: http://some-site.com"
+    $ curl -i https://api.github.com -H "Origin: http://example.com"
     HTTP/1.1 302 Found
 
 Any domain that is registered as an OAuth Application is accepted.
@@ -429,7 +429,7 @@ foo({
 })
 </pre>
 
-You can write a javascript handler to process the callback like this:
+You can write a JavaScript handler to process the callback like this:
 
 <pre class="highlight"><code class="language-javascript">function foo(response) {
   var meta = response.meta

--- a/content/v3/oauth.md
+++ b/content/v3/oauth.md
@@ -105,13 +105,13 @@ redirect users to the callback URL configured in the OAuth Application
 settings. If provided, the redirect URL must match the callback URL's
 host.
 
-    CALLBACK: http://foo.com
+    CALLBACK: http://example.com
 
-    GOOD: https://foo.com
-    GOOD: http://foo.com/bar
-    BAD:  http://foo.com:8080
-    BAD:  http://oauth.foo.com:8080
-    BAD:  http://bar.com
+    GOOD: https://example.com
+    GOOD: http://example.com/bar
+    BAD:  http://example.com:8080
+    BAD:  http://oauth.example.com:8080
+    BAD:  http://example.org
 
 ## Scopes
 

--- a/content/v3/repos/hooks.md
+++ b/content/v3/repos/hooks.md
@@ -39,10 +39,10 @@ The payloads for all of the hooks mirror [the payloads for the Event
 types](/v3/activity/events/types/), with the exception of [the original `push`
 event](http://help.github.com/post-receive-hooks/).
 
-A number of external services have already been integrated through the open source 
-[github-services](https://github.com/github/github-services) project, including the generic 
-[Web Service](https://github.com/github/github-services/blob/master/services/web.rb) service which can be used to 
-define your own custom hooks. All possible names for hooks, the events they support, and their configuration can be seen at  [/hooks](https://api.github.com/hooks).
+A number of external services have already been integrated through the open source
+[github-services](https://github.com/github/github-services) project, including the generic
+[Web Service](https://github.com/github/github-services/blob/master/services/web.rb) service which can be used to
+define your own custom hooks. All possible names for hooks, the events they support, and their configuration can be seen at [/hooks](https://api.github.com/hooks).
 
 For a Hook to go through, the Hook needs to be configured to trigger for
 an event, and the Service has to listen to it.   Most of the Services only listen for `push` events.  However, the generic [Web Service](https://github.com/github/github-services/blob/master/services/web.rb) listens for all events.  Other services like the [IRC Service](https://github.com/github/github-services/blob/master/services/irc.rb) may only listen for `push`, `issues`, and `pull_request` events.
@@ -106,7 +106,7 @@ legacy format):
       :active => true,
       :events => ['push', 'pull_request'],
       :config => {
-        :url => 'http://something.com/webhook',
+        :url => 'http://example.com/webhook',
         :content_type => 'json'}
 %>
 
@@ -137,7 +137,7 @@ JSON true/false values will be converted automatically.
 
 
 
-You can change a hook to send straight JSON by 
+You can change a hook to send straight JSON by
 
 `events`
 : _Optional_ **array** - Determines what events the hook is triggered


### PR DESCRIPTION
Since some-site.com is active, and foo.com is a for sale sign, it may be better to use the IANA domains set aside for examples and illustrative cases.

The response headers looked the same when testing for the CORS section.
