### PR TITLE
Fix the "removing label from an issue" response

### DIFF
--- a/content/v3/issues/labels.md
+++ b/content/v3/issues/labels.md
@@ -101,8 +101,7 @@ color
 
 ### Response
 
-<%= headers 200 %>
-<%= json(:label) { |h| [h] } %>
+<%= headers 204 %>
 
 ## Replace all labels for an issue
 


### PR DESCRIPTION
It's supposed to be a 204, not a 200 with the list of label names returned.

(Confirmed by @pengwynn)
