### PR TITLE
Add link to 'get tree recursively'

### DIFF
--- a/content/v3/repos/contents.md
+++ b/content/v3/repos/contents.md
@@ -45,6 +45,9 @@ ref
 <%= headers 200 %>
 <%= json :readme_content %>
 
+### Notes
+To get a repository's contents recursively, you can [recursively get the tree](../git/trees)
+
 ## Get archive link
 
 This method will return a `302` to a URL to download a tarball


### PR DESCRIPTION
Add a note to the 'Get repo contents' section mentioning that to get a content listing recursively (not possible with 'contents'), one can use the repo's tree instead.
This is a bit difficult to find if one does not know the API, so should be worth noting here.

In reaction to a question brought up on IRC, and solved by @michaelhood
