### PR TITLE
Add subject.type field to thread resource

### DIFF
--- a/lib/resources.rb
+++ b/lib/resources.rb
@@ -1012,7 +1012,8 @@ module GitHub
       :subject => {
         :title => "Greetings",
         :url => "https://api.github.com/repos/pengwynn/octokit/issues/123",
-        :latest_comment_url => "https://api.github.com/repos/pengwynn/octokit/issues/comments/123"
+        :latest_comment_url => "https://api.github.com/repos/pengwynn/octokit/issues/comments/123",
+        :type => "Issue"
       },
       :reason => 'subscribed',
       :unread => true,


### PR DESCRIPTION
I tried to build this with `nanoc` (to avoid another embarrassing comma snafu) by running:

```
bundle install
gem install nanoc
nanoc compile
```

Everything up until compilation seemed to work, then I got the following error:

```
LoadError: cannot load such file -- yajl/json_gem
```
