### PR TITLE
v3.md: Link to the final RFC for the Link header

### DIFF
--- a/content/v3.md
+++ b/content/v3.md
@@ -250,7 +250,7 @@ $ curl https://api.github.com/user/repos?page=2&per_page=100
 </pre>
 
 The pagination info is included in [the Link
-header](http://www.w3.org/Protocols/9707-link-header.html). It is important to
+header](http://tools.ietf.org/html/rfc5988). It is important to
 follow these Link header values instead of constructing your own URLs. In some
 instances, such as in the [Commits
 API](/v3/repos/commits/), pagination is based on


### PR DESCRIPTION
Previous version linked to an old W3C draft. 
