### PR TITLE
Add scope requirements and curl example for Star a repository.

### DIFF
--- a/content/v3/activity/starring.md
+++ b/content/v3/activity/starring.md
@@ -83,6 +83,7 @@ Requires for the user to be authenticated.
 ## Star a repository
 
 Requires for the user to be authenticated.
+Requires the `public_repo` scope.
 
     PUT /user/starred/:owner/:repo
 
@@ -92,6 +93,12 @@ Requires for the user to be authenticated.
 ### Response
 
 <%= headers 204 %>
+
+### Example
+
+<pre class="terminal">
+$ curl -D- -XPUT -H "Authorization: token OAUTH-TOKEN" -H "Content-length: 0" https://api.github.com/user/starred/:owner/:repo
+</pre>
 
 ## Unstar a repository
 


### PR DESCRIPTION
Hi guys,
this patch adds scope requirements and curl example for the Star a repository action.

I had to first figure out which scope was needed by my application, then had to define
`Content-length: 0` header when sending the PUT request - otherwise it didn't work. So decided to document that.
