### PR TITLE
Updated 'Basics of Authentication' guide to reflect changes to rest_client gem

### DIFF
--- a/content/guides/basics-of-authentication.md
+++ b/content/guides/basics-of-authentication.md
@@ -60,8 +60,7 @@ Next, in _views/index.erb_, paste this content:
       </body>
     </html>
 
-(If you're unfamiliar with how Sinatra works, we recommend [reading the
-Sinatra guide][Sinatra guide].)
+(If you're unfamiliar with how Sinatra works, we recommend [reading the Sinatra guide][Sinatra guide].)
 
 Obviously, you'll want to change `<your_client_id>` to match your actual Client ID. 
 


### PR DESCRIPTION
The [rest_client](https://github.com/rest-client/rest-client) gem has been renamed and is pulled using `gem install rest-client` instead of `gem install rest_client`. I made a couple minor changes to the guide in order to reflect this.
