### PR TITLE
Reformatting to better indicate how to send `:accept` header

### DIFF
--- a/content/guides/basics-of-authentication.md
+++ b/content/guides/basics-of-authentication.md
@@ -86,8 +86,10 @@ In _server.rb_, add a route to specify what the callback should do:
       result = RestClient.post("https://github.com/login/oauth/access_token",
                               {:client_id => CLIENT_ID,
                                :client_secret => CLIENT_SECRET,
-                               :code => session_code},
-                               :accept => :json)
+                               :code => session_code
+                              },{
+                               :accept => :json
+                              })
       access_token = JSON.parse(result)["access_token"]
     end
 


### PR DESCRIPTION
Reformatting example to better indicate the `:accept` header is sent as a separate parameter. Before, it looked like it was part of the same hash. 
