### PR TITLE
List statuses doesn't have parameters

### DIFF
--- a/content/v3/repos/statuses.md
+++ b/content/v3/repos/statuses.md
@@ -29,11 +29,6 @@ access to Statuses **without** also granting access to repo code, while the
 
     GET /repos/:owner/:repo/statuses/:sha
 
-### Parameters
-
-sha
-: _Required_ **string** - Sha to list the statuses from
-
 ### Response
 
 <%= headers 200 %>


### PR DESCRIPTION
The SHA is in the URL. A GET parameter is not needed.
