### PR TITLE
D3 example tighten

### DIFF
--- a/content/guides/rendering-data-as-graphs.md
+++ b/content/guides/rendering-data-as-graphs.md
@@ -333,7 +333,7 @@ tweak the height and width of your treemap, passed as the first two
 arguments to `drawTreemap` above, to get all the information to show up properly.
 
 
-[D3.js]: http://D3js.org/
+[D3.js]: http://d3js.org/
 [basics-of-authentication]: ../basics-of-authentication/
 [sinatra auth github]: https://github.com/atmos/sinatra_auth_github
 [Octokit]: https://github.com/pengwynn/octokit


### PR DESCRIPTION
I was reading the "rendering data as graphs" article and wanted to fix some small consistency issues (OctoKit versus Octokit, and using "D3", more canonical than the lowercase "d3") and a couple of typos.

I ended up making some prose updates that I felt tightened up or otherwise improved the flow of the guide, but I can submit a different pull with just spelling corrections/consistency if you're not into the changes. Just let me know.
