### PR TITLE
Link to Octokit libraries

### DIFF
--- a/content/v3/libraries.md
+++ b/content/v3/libraries.md
@@ -68,7 +68,7 @@ GitHub v3 API.  Builds are available in [Maven Central](http://search.maven.org/
 
 ## Objective-C
 
-* **[Octokit][octokit.objc]** (officially maintained by GitHub)
+* **[OctoKit][octokit.objc]** (officially maintained by GitHub)
 * [UAGithubEngine][uagithubengine]
 
 [octokit.objc]: https://github.com/octokit/octokit.objc


### PR DESCRIPTION
And highlight the official nature of [Octokit](http://octokit.github.io).

@pengwynn 
