### PR TITLE
Clarify what /repositories does

### DIFF
--- a/content/v3/repos.md
+++ b/content/v3/repos.md
@@ -57,9 +57,9 @@ type
 <%= headers 200, :pagination => true %>
 <%= json(:repo) { |h| [h] } %>
 
-## List all repositories
+## List all public repositories
 
-This provides a dump of every repository, in the order that they were created.
+This provides a dump of every public repository, in the order that they were created.
 
     GET /repositories
 


### PR DESCRIPTION
What this really did wasn't made explicitly clear – only inferred due to users obviously not having access to private repositories that they don't own. This made the behavior unclear in the context of Enterprise where it would make sense for an admin to have access to private repositories.
