### PR TITLE
Clarify how pagination works for /users

### DIFF
--- a/content/v3/users.md
+++ b/content/v3/users.md
@@ -76,7 +76,8 @@ bio
 ## Get all users
 
 This provides a dump of every user, in the order that they signed up for
-GitHub.
+GitHub. Note that the `since` parameter is required in addition to the
+`page` parameter when using pagination.
 
     GET /users
 


### PR DESCRIPTION
Once you see an example of this in the Link header, this becomes obvious. However, if you read the Pagination page, it appears as though simply including `?page=2` should work because nothing else is noted with this request method.
