### PR TITLE
Keep all support enquiries via GitHub contact page

### DIFF
--- a/content/v3.md
+++ b/content/v3.md
@@ -6,7 +6,7 @@ title: GitHub API v3
 
 This describes the resources that make up the official GitHub API v3. If
 you have any problems or requests please contact
-[support](mailto:support@github.com?subject=APIv3).
+[support](https://github.com/contact).
 
 * TOC
 {:toc}


### PR DESCRIPTION
Not sure if this is _really_ an issue however everywhere else directs users to use the contact form on GitHub - just to keep consistency.

Ideally, it would be cool if https://github.com/contact would accept URL params like `?subject=APIv3` and then the support contact form would pick up on those extra pieces of data.
