### PR TITLE
User-Agent Example

### DIFF
--- a/content/v3.md
+++ b/content/v3.md
@@ -333,12 +333,13 @@ higher rate limit for your OAuth application.
 ## User Agent Required
 
 All API requests MUST include a valid `User-Agent` header. Requests with no `User-Agent`
-header will be rejected. If you are hitting the API without authentication, we ask that
-you add some kind of identification to the UA header value. This is so we can contact
-you if there are problems.
+header will be rejected. We request that you use your GitHub username, or the name of your 
+application, for the `User-Agent` header value. This allows us to contact you if there are problems.
+
+Here's an example:
 
 <pre class="terminal">
-User-Agent: Octocat
+User-Agent: Awesome-Octocat-App
 </pre>
 
 ## Conditional requests


### PR DESCRIPTION
I was venturing into the wonderful world of the GitHub API tonight and was sent to this part of the docs through an error message I got about a User Agent. I found the docs a little confusing. From what I learned, the docs could be more clear by specifying that the user agent must be a _header_ (it currently says string) and written like `user-agent` since it is a header and has to be hyphenated (it currently says User Agent). I also thought an example would be helpful as well. This PR makes little changes to this effect.

![screen shot 2013-06-11 at 11 05 51 pm](https://f.cloud.github.com/assets/1305617/641157/c396b800-d326-11e2-9205-c699c26db8b2.png)

Also, it says "All API requests MUST include" but then says "If you are hitting the API without authentication." If it MUST include something then how can you possibly be hitting the API without it? Maybe I'm just too much a n00b in the world of APIs but I thought it was worth mentioning. 

Woo! :cat2: 
