### PR TITLE
Add the Joomla! GitHub package to the libraries list

### DIFF
--- a/content/v3/libraries.md
+++ b/content/v3/libraries.md
@@ -101,10 +101,12 @@ GitHub v3 API.  Builds are available in [Maven Central](http://search.maven.org/
 * [PHP GitHub API][php-github-api]
 * [GitHub API][github-api]
 * [GitHub Kohana Module][kohana]
+* [GitHub Joomla! Package][joomla]
 
 [php-github-api]: https://github.com/KnpLabs/php-github-api
 [github-api]: https://github.com/yiiext/github-api
 [kohana]: https://github.com/acoulton/github_v3_api
+[joomla]: https://github.com/joomla/joomla-framework
 
 ## Python
 


### PR DESCRIPTION
Hi,
we've just finished the GitHub API implementation for the Joomla! framework and would be very proud if it could be included in the libraries list.

It is complete, unit tested, has a fluent interface, supports basic and oAuth authentication and follows the GitHub API documentation in its semantic.

Have a look: [Joomla! GitHub API](https://github.com/joomla/joomla-framework/tree/staging/src/Joomla/Github)

Thanks for providing such a great service :smile_cat: 
