### PR TITLE
Bring the changes section up to style with the blog

### DIFF
--- a/layouts/_changes.html
+++ b/layouts/_changes.html
@@ -1,6 +1,6 @@
 <% @changes.each do |article| %>
 <div class="change" id="<%= article.path %>">
   <%= render '_meta', :item => article %>
-  <%= article.compiled_content %>
+    <%= article.compiled_content %>
 </div>
 <% end %>

--- a/layouts/_meta.html
+++ b/layouts/_meta.html
@@ -3,16 +3,17 @@
 </h2>
 
 <div class="meta">
-  <div class="who_when">
-    <%= gravatar_for(@item[:author_name]) %>
-    <span class="author vcard fn">
-      <a href="https://github.com/<%= @item[:author_name] %>"><%= @item[:author_name] %></a>
-    </span>
-    <span class="published">
-      <%= post_date @item %>
+  <ul>
+  <li class="published">
+    <span class="octicon octicon-calendar"></span>
+    <%= post_date @item %>
     <% if version = @item[:api_version] %>
       / Version: <a href="/changes/<%= version %>"><%= version %></a>
     <% end %>
-    </span>
-  </div>
+  </li>
+  <li class="who_when">
+    <%= gravatar_for(@item[:author_name]) %>
+      <a href="https://github.com/<%= @item[:author_name] %>"><%= @item[:author_name] %></a>
+  </li>
+</ul>
 </div>

--- a/static/shared/css/documentation.css
+++ b/static/shared/css/documentation.css
@@ -29,6 +29,18 @@
   content: "\f00a";
 }
 
+.octicon-calendar:before {
+  content: "\f068";
+}
+
+.octicon {
+  font: normal normal 16px "octiconsregular";
+  line-height: 1;
+  display: inline-block;
+  text-decoration: none;
+  -webkit-font-smoothing: antialiased;
+}
+
 /* end */
 
 /*------------------------------------------------------------------------------
@@ -80,7 +92,7 @@ h2 {
   body.api .change h2.title {
     background: none;
     line-height: 1.2em;
-    margin-bottom: 0;
+    margin-bottom: 10px;
     padding-left: 0;
     font-size:24px;
   }
@@ -464,8 +476,8 @@ div.sidebar-module ul ul li span {
 }
 
 .content ul {
+  margin: 1.5em;
   list-style-type: disc;
-  margin: 1.5em
 }
 
 .content dd ul {
@@ -525,13 +537,22 @@ p code {
   color: #868686;
 }
 
+.article-content ul {
+  margin: 1.5em;
+}
+
 .change {
   padding-bottom: 1em;
 }
 
+
   .change .meta {
-    font-size: 16px;
-    padding-bottom: 1em;
+    font-size: 14px;
+  }
+
+  .who_when a {
+    padding-left: 6px;
+    color: #999;
   }
 
     .change .who_when .author {
@@ -541,6 +562,24 @@ p code {
     .change .who_when .published {
       color: #ccc;
     }
+
+  .meta {
+    margin-left: -19px;
+    margin-top: -15px;
+  }
+
+  .meta li {
+    color: #999;
+    padding-right: 20px;
+    list-style: none;
+    display: inline;
+  }
+
+  .published span {
+    color: #999;
+    vertical-align: middle;
+    padding-bottom: 3px;
+  }
 
 /* @end */
 


### PR DESCRIPTION
These UI updates will bring the API changes section up to speed with the new blog styling for the meta data. This pull request also refactors some of the markup to be better structured.

![api-meta-changes](http://share.jacobbednarz.com/api-changes-update-20130619-210339.png)

I have compiled and tested this locally however it would be really good if I could get another set of eyes to go over parts of the documentation just to be sure this doesn't break anything else.
