### PR TITLE
A better example of output for repository contents.

### DIFF
--- a/lib/resources.rb
+++ b/lib/resources.rb
@@ -1100,18 +1100,18 @@ module GitHub
 
     CONTENT_CRUD = {
       "content" => {
-        "name" => "hellothere",
-        "path" => "hellothere",
+        "name" => "hello.txt",
+        "path" => "notes/hello.txt",
         "sha" => "95b966ae1c166bd92f8ae7d1c313e738c731dfc3",
         "size" => 9,
-        "url" => "https://api.github.com/repos/octocat/Hello-World/contents/hellothere",
-        "html_url" => "https://github.com/octocat/Hello-World/blob/master/hellothere",
+        "url" => "https://api.github.com/repos/octocat/Hello-World/contents/notes/hello.txt",
+        "html_url" => "https://github.com/octocat/Hello-World/blob/master/notes/hello.txt",
         "git_url" => "https://api.github.com/repos/octocat/Hello-World/git/blobs/95b966ae1c166bd92f8ae7d1c313e738c731dfc3",
         "type" => "file",
         "_links" => {
-          "self" => "https://api.github.com/repos/octocat/Hello-World/contents/hellothere",
+          "self" => "https://api.github.com/repos/octocat/Hello-World/contents/notes/hello.txt",
           "git" => "https://api.github.com/repos/octocat/Hello-World/git/blobs/95b966ae1c166bd92f8ae7d1c313e738c731dfc3",
-          "html" => "https://github.com/octocat/Hello-World/blob/master/hellothere"
+          "html" => "https://github.com/octocat/Hello-World/blob/master/notes/hello.txt"
         }
       },
       "commit" => {


### PR DESCRIPTION
A better example of output for repository contents which demonstrates the difference between the `name` and `path` fields, which the previous example didn't.
