### PR TITLE
added octohub: low level python and cli interface to github

### DIFF
--- a/content/v3/libraries.md
+++ b/content/v3/libraries.md
@@ -117,6 +117,7 @@ GitHub v3 API.  Builds are available in [Maven Central](http://search.maven.org/
 * [sanction][sanction]
 * [agithub][agithub]
 * [githubpy][githubpy]
+* [octohub][octohub]
 
 [jacquev6_pygithub]: https://github.com/jacquev6/PyGithub
 [pygithub3-api]: https://github.com/copitux/python-github3
@@ -125,6 +126,7 @@ GitHub v3 API.  Builds are available in [Maven Central](http://search.maven.org/
 [sanction]: https://github.com/demianbrecht/sanction
 [agithub]: https://github.com/jpaugh64/agithub "Agnostic GitHub"
 [githubpy]: https://github.com/michaelliao/githubpy
+[octohub]: https://github.com/turnkeylinux/octohub
 
 ## Ruby
 


### PR DESCRIPTION
OctoHub is a Python package that provides a low level interface to the full GitHub v3 API.

It was developed out of a need to have a one-to-one interface to the GitHub API based on the excellent online documentation, with the least amount of abstraction. Although, it does do its part by parsing raw JSON responses into Pythonic attribute dictionaries, as well providing an optional iterative Pager for handling pagination.

Also included is a command line interface for quick interaction with GitHub's API, as well as higher level contrib scripts (currently offline-issues and gist, but more coming...).
