### PR TITLE
Added open_issues_count to REPO resource to match API output.

### DIFF
--- a/lib/resources.rb
+++ b/lib/resources.rb
@@ -167,23 +167,24 @@ module GitHub
     }
 
     REPO = SIMPLE_REPO.merge({
-      "clone_url"        => "https://github.com/octocat/Hello-World.git",
-      "git_url"          => "git://github.com/octocat/Hello-World.git",
-      "ssh_url"          => "git@github.com:octocat/Hello-World.git",
-      "svn_url"          => "https://svn.github.com/octocat/Hello-World",
-      "mirror_url"       => "git://git.example.com/octocat/Hello-World",
-      "homepage"         => "https://github.com",
-      "language"         => nil,
-      "forks"            => 9,
-      "forks_count"      => 9,
-      "watchers"         => 80,
-      "watchers_count"   => 80,
-      "size"             => 108,
-      "master_branch"    => 'master',
-      "open_issues"      => 0,
-      "pushed_at"        => "2011-01-26T19:06:43Z",
-      "created_at"       => "2011-01-26T19:01:12Z",
-      "updated_at"       => "2011-01-26T19:14:43Z"
+      "clone_url"         => "https://github.com/octocat/Hello-World.git",
+      "git_url"           => "git://github.com/octocat/Hello-World.git",
+      "ssh_url"           => "git@github.com:octocat/Hello-World.git",
+      "svn_url"           => "https://svn.github.com/octocat/Hello-World",
+      "mirror_url"        => "git://git.example.com/octocat/Hello-World",
+      "homepage"          => "https://github.com",
+      "language"          => nil,
+      "forks"             => 9,
+      "forks_count"       => 9,
+      "watchers"          => 80,
+      "watchers_count"    => 80,
+      "size"              => 108,
+      "master_branch"     => 'master',
+      "open_issues"       => 0,
+      "open_issues_count" => 0,
+      "pushed_at"         => "2011-01-26T19:06:43Z",
+      "created_at"        => "2011-01-26T19:01:12Z",
+      "updated_at"        => "2011-01-26T19:14:43Z"
     })
 
     FULL_REPO = REPO.merge({


### PR DESCRIPTION
The REPO resource already contained `open_issues`, but didn't contain `open_issues_count`, which is also contained in the API output.
`forks`, `watchers`, and `open_issues` are respectively equivalent to `forks_count`, `watchers_count`, and `open_issues_count`. The non `_count` versions of these fields only exist for backwards compatibility.
