### PR TITLE
Fix the link in PullRequestReviewCommentEvent docs

### DIFF
--- a/content/v3/activity/events/types.md
+++ b/content/v3/activity/events/types.md
@@ -188,7 +188,7 @@ pull\_request
 Hook name: `pull_request_review_comment`
 
 comment
-: **object** - The [comment](/v3/repos/commits/#list-commit-comments-for-a-repository) itself.
+: **object** - The [comment](/v3/pulls/comments) itself.
 
 ## PushEvent
 


### PR DESCRIPTION
The "comment" link in the PullRequestReviewCommentEvent documentation pointed at the docs for commit comment, not pull request comments. This fixes that.
