### PR TITLE
Set "fork": true for Fork responses

### DIFF
--- a/content/v3/repos/forks.md
+++ b/content/v3/repos/forks.md
@@ -19,7 +19,7 @@ sort
 ### Response
 
 <%= headers 200 %>
-<%= json(:repo) { |h| [h] } %>
+<%= json(:repo) { |h| h['fork'] = true; [h] } %>
 
 ## Create a fork
 
@@ -43,4 +43,4 @@ a short period before accessing the git objects.  If this takes longer than
 5 minutes, be sure to [contact Support](https://github.com/contact?form[subject]=APIv3).
 
 <%= headers 202 %>
-<%= json :repo %>
+<%= json(:repo) { |h| h['fork'] = true; h } %>


### PR DESCRIPTION
The JSON response examples on the `repos/forks` page currently shows output that has `"fork":false`. This PR just makes the responses make more sense in the context.
