### PR TITLE
Better OAuth2 token consistency

### DIFF
--- a/content/v3.md
+++ b/content/v3.md
@@ -191,7 +191,7 @@ $ curl -u "username" https://api.github.com
 ### OAuth2 Token (sent in a header)
 
 <pre class="terminal">
-$ curl -H "Authorization: bearer OAUTH-TOKEN" https://api.github.com
+$ curl -H "Authorization: token OAUTH-TOKEN" https://api.github.com
 </pre>
 
 ### OAuth2 Token (sent as a parameter)

--- a/content/v3/oauth.md
+++ b/content/v3/oauth.md
@@ -132,7 +132,7 @@ authorize form.
 Check headers to see what OAuth scopes you have, and what the API action
 accepts.
 
-    $ curl -H "Authorization: bearer OAUTH-TOKEN" https://api.github.com/users/technoweenie -I
+    $ curl -H "Authorization: token OAUTH-TOKEN" https://api.github.com/users/technoweenie -I
     HTTP/1.1 200 OK
     X-OAuth-Scopes: repo, user
     X-Accepted-OAuth-Scopes: user


### PR DESCRIPTION
We should be using an Authorization header value of "Authorization: bearer OAUTH-TOKEN" consistently throughout the docs.
