### PR TITLE
Add note that email is the public email.

### DIFF
--- a/content/v3/users.md
+++ b/content/v3/users.md
@@ -15,6 +15,8 @@ information](/v3/#authentication) with your request).
 
 ## Get a single user
 
+Note: The returned email is the user's publicly visible email address.
+
     GET /users/:user
 
 ### Response


### PR DESCRIPTION
Where users have access to other user's information through the website, such as administrators of GitHub Enterprise installations, it's not obvious that the email returned in a call to `/users/:user` is that user's public email address rather than email addresses added to the account. This pull request adds a note (hopefully) making that clear. 
