### PR TITLE
Clarify docs for creating inline commit comments

### DIFF
--- a/content/v3/repos/comments.md
+++ b/content/v3/repos/comments.md
@@ -49,16 +49,16 @@ position
 : _Optional_ **number** - Line index in the diff to comment on.
 
 line
+: _Deprecated_ - Use **position** parameter instead.
 : _Optional_ **number** - Line number in the file to comment on. Defaults to `null`.
-
 
 #### Example
 
 <%= json \
   :body      => 'Nice change',
-  :line      => nil,
   :path      => 'file1.txt',
-  :position  => 4
+  :position  => 4,
+  :line      => nil
 %>
 
 ### Response


### PR DESCRIPTION
The `position` parameter identifies the position of the comment within the diff. Use the `position` parameter for this purpose, not the `line` parameter.

The `line` parameter is a vestige of an earlier version of the API.
