### PR TITLE
Clarifies what `GET /user/repos` returns.

### DIFF
--- a/content/v3/repos.md
+++ b/content/v3/repos.md
@@ -11,7 +11,9 @@ title: Repos | GitHub API
 
 List repositories for the authenticated user. Note that this does not include
 repositories owned by organizations which the user can access. You can
-[list user organizations](/v3/orgs/#list-user-organizations) separately.
+[list user organizations](/v3/orgs/#list-user-organizations) and
+[list organization repositories](/v3/repos/#list-organization-repositories)
+separately.
 
     GET /user/repos
 


### PR DESCRIPTION
There have been several instances of people contacting support, confused about the why `GET /user/repos` doesn't include repos owned by organizations which the user can access. This clarifies what's returned.
