### PR TITLE
More accurate Location header for Get archive link

### DIFF
--- a/content/v3/repos/contents.md
+++ b/content/v3/repos/contents.md
@@ -271,7 +271,7 @@ ref
 
 ### Response
 
-<%= headers 302, :Location => 'http://github.com/me/myprivate/tarball/master?SSO=thistokenexpires' %>
+<%= headers 302, :Location => 'https://codeload.github.com/me/myprivate/legacy.zip/master?login=me&token=thistokenexpires' %>
 
 To follow redirects with curl, use the `-L` switch:
 


### PR DESCRIPTION
Update the `Get archive link` response example to better reflect paths and parameters returned in the `Location` header.
