### PR TITLE
Add a simple python OAuth example using requests-oauthlib.

### DIFF
--- a/content/v3/oauth.md
+++ b/content/v3/oauth.md
@@ -354,6 +354,7 @@ links that might be of help:
 * [Facebook Login API](http://developers.facebook.com/docs/technical-guides/login/)
 * [Ruby OAuth2 lib](https://github.com/intridea/oauth2)
 * [Simple Ruby/Sinatra example](https://gist.github.com/9fd1a6199da0465ec87c)
+* [Python Flask example](https://gist.github.com/ib-lundgren/6507798) using [requests-oauthlib](https://github.com/requests/requests-oauthlib)
 * [Simple Python example](https://gist.github.com/e3fbd47fbb7ee3c626bb) using [python-oauth2](https://github.com/dgouldin/python-oauth2)
 * [Ruby OmniAuth example](https://github.com/intridea/omniauth)
 * [Ruby Sinatra extension](https://github.com/atmos/sinatra_auth_github)


### PR DESCRIPTION
A [fully working example](https://gist.github.com/ib-lundgren/6507798) of how to get an OAuth 2 token for a GitHub user and use it to fetch a user profile. It uses the Flask web framework but should be easily transferable to other frameworks. Unlike the current example it uses the [requests-oauthlib](https://github.com/requests/requests-oauthlib) library.
