### PR TITLE
Clarify start of week timestamp in repository statistics API

### DIFF
--- a/content/v3/repos/statistics.md
+++ b/content/v3/repos/statistics.md
@@ -35,7 +35,7 @@ which is usually master; pushing to the default branch resets the statistics cac
 
 **Weekly Hash**
 
-* `w` - Start of the week
+* `w` - Start of the week, given as a [Unix timestamp](http://en.wikipedia.org/wiki/Unix_time).
 * `a` - Number of additions
 * `d` - Number of deletions
 * `c` - Number of commits


### PR DESCRIPTION
This PR clarifies that the `w` attribute in the [Repository statistics API](http://developer.github.com/v3/repos/statistics/) is a Unix timestamp of the start of the week (+ a link to the Wikipedia article for Unix time).
