### PR TITLE
Change reference of defunct OAuth application

### DIFF
--- a/content/v3.md
+++ b/content/v3.md
@@ -438,9 +438,9 @@ Here's a sample request sent from a browser hitting
     HTTP/1.1 302 Found
 
 Any domain that is registered as an OAuth Application is accepted.
-Here's a sample request for a browser hitting [Calendar About Nothing](http://calendaraboutnothing.com/):
+Here's a sample request for a browser hitting [Travis CI](http://travis-ci.org/):
 
-    $ curl -i https://api.github.com -H "Origin: http://calendaraboutnothing.com"
+    $ curl -i https://api.github.com -H "Origin: http://travis-ci.org"
     HTTP/1.1 302 Found
     Access-Control-Allow-Origin: *
     Access-Control-Expose-Headers: ETag, Link, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes
@@ -448,7 +448,7 @@ Here's a sample request for a browser hitting [Calendar About Nothing](http://ca
 
 This is what the CORS preflight request looks like:
 
-    $ curl -i https://api.github.com -H "Origin: http://calendaraboutnothing.com" -X OPTIONS
+    $ curl -i https://api.github.com -H "Origin: http://travis-ci.org" -X OPTIONS
     HTTP/1.1 204 No Content
     Access-Control-Allow-Origin: *
     Access-Control-Allow-Headers: Authorization, Content-Type, If-Match, If-Modified-Since, If-None-Match, If-Unmodified-Since, X-Requested-With


### PR DESCRIPTION
The domain of the web application previously referenced by the CORS documentation, Calendar About Nothing, has expired (as seen by the "This Domain Name Has Expired" message on the linked page). This section has been updated to refer to Travis CI, a continuous integration tool that seems very popular among GitHub users.
