### PR TITLE
Add list of supported media types for pull request review comments

### DIFF
--- a/content/v3/pulls/comments.md
+++ b/content/v3/pulls/comments.md
@@ -136,3 +136,12 @@ body
 
 <%= headers 204 %>
 
+## Custom media types
+
+These are the supported media types for pull request review comments. You can
+read more about the use of media types in the API [here](/v3/media/).
+
+    application/vnd.github.VERSION.raw+json
+    application/vnd.github.VERSION.text+json
+    application/vnd.github.VERSION.html+json
+    application/vnd.github.VERSION.full+json


### PR DESCRIPTION
This fixes a broken link in the docs page for [Pull Request Review Comments](http://developer.github.com/v3/pulls/comments/) by adding the list of supported media types at the bottom of the page:

> Pull Request Review Comments use [these custom media types](http://developer.github.com/v3/pulls/comments/#custom-media-types) _(this was the broken link)_. You can read more about the use of media types in the API [here](http://developer.github.com/v3/media/).

Pull request review comments support the same media types as issue comments.
