### PR TITLE
Rename status link to statuses in pull request API

### DIFF
--- a/lib/resources.rb
+++ b/lib/resources.rb
@@ -356,7 +356,7 @@ module GitHub
       "diff_url"   => "https://github.com/octocat/Hello-World/pulls/1.diff",
       "patch_url"  => "https://github.com/octocat/Hello-World/pulls/1.patch",
       "issue_url"  => "https://github.com/octocat/Hello-World/issue/1",
-      "status_url" => "https://api.github.com/repos/octocat/Hello-World/statuses/6dcb09b5b57875f334f61aebed695e2e4193db5e",
+      "statuses_url" => "https://api.github.com/repos/octocat/Hello-World/statuses/6dcb09b5b57875f334f61aebed695e2e4193db5e",
       "number"     => 1,
       "state"      => "open",
       "title"      => "new-feature",
@@ -388,7 +388,7 @@ module GitHub
           "https://api.github.com/repos/octocat/Hello-World/issues/1/comments"},
         "review_comments" => {'href' =>
           "https://api.github.com/repos/octocat/Hello-World/pulls/1/comments"},
-        "status" => {'href' =>
+        "statuses" => {'href' =>
           "https://api.github.com/repos/octocat/Hello-World/statuses/6dcb09b5b57875f334f61aebed695e2e4193db5e"}
       },
       "user" => USER


### PR DESCRIPTION
This documents the rename of the `status` and `status_url` links in the pull request API to `statuses` and `statuses_url`.

cc @jasonrudolph @gjtorikian 
