### PR TITLE
Add docs for SSL versioning

### DIFF
--- a/content/v3/troubleshooting.md
+++ b/content/v3/troubleshooting.md
@@ -39,7 +39,7 @@ our safety. You can read more about it [here](/v3/#rate-limiting).
 If you're using OAuth or Basic Authentication and are hitting your rate limits,
 you might be able to fix the issue by either caching our results, or [using conditional requests](/v3/#conditional-requests).
 
-In certainly exceptional cases, we may temporarily bump your rate limit higher. You
+In certain exceptional cases, we may temporarily bump your rate limit higher. You
 should be prepared to answer technical questions about your goal and your planned usage of the API. We may still choose not to bump your limit if we feel that you can achieve your wildest
 dreams with the current rate limit (but don't worry, we'll help you out).
 


### PR DESCRIPTION
There have been a few occurrences where remote servers do not successfully do SSL negotiation. This documentation patch explains how to correctly specify a specific SSL version for WebHooks.
