### PR TITLE
Resolve incorrect content type for JSON POST payload

### DIFF
--- a/content/v3.md
+++ b/content/v3.md
@@ -59,7 +59,7 @@ and `:repo` parameters in the path while `:state` is passed in the query
 string.
 
 For POST, PATCH, PUT, and DELETE requests, parameters not included in the URL should be encoded as JSON
-with a Content-Type of 'application/x-www-form-urlencoded':
+with a Content-Type of 'application/json':
 
 <pre class="terminal">
 $ curl -i -u username -d '{"scopes":["public_repo"]}' https://api.github.com/authorizations


### PR DESCRIPTION
Should the JSON payload not be encoded with an `application/json` payload, as `application/x-www-form-urlencoded` implies URL encoded path params for attributes..
