### PR TITLE
POST /gists does not require :public

### DIFF
--- a/content/v3/gists.md
+++ b/content/v3/gists.md
@@ -66,7 +66,7 @@ description
 : _Optional_ **string**
 
 public
-: _Required_ **boolean**
+: _Optional_ **boolean** - If missing, the gist will be secret.
 
 files
 : _Required_ **hash** - Files that make up this gist. The key of which


### PR DESCRIPTION
There is a mismatch between the documentation and the API.

If I `POST /gists` without passing a `public` parameter, the gist gets created (201 returned) and is visible at http://gist.github.com -- however the response has the attribute `public` set to nil.

If this is the desired behavior, then my commit fixes the documentation to match the API.

If this is not the desired behavior, then the API should return 422 if `public` is not specified
