### PR TITLE
Add statuses to the list of link relations for pull requests

### DIFF
--- a/content/v3/pulls.md
+++ b/content/v3/pulls.md
@@ -32,7 +32,7 @@ Pull Requests have these possible link relations:
 : The API location of this Pull Request's Review comments.
 
 `statuses`
-: The API location of this Pull Request's statuses, which are the statuses of its `head` branch.
+: The API location of this Pull Request's commit statuses, which are the statuses of its `head` branch.
 
 ## List pull requests
 


### PR DESCRIPTION
I just noticed that I forgot to do this in [this pull request](https://github.com/github/developer.github.com/pull/312) when I added the new `statuses` and `statuses_url` links to the example API responses.

So, this documents the new `statuses` link relation in the list of pull request link relations.
