### PR TITLE
API endpoints default to the repository's default branch, not necessarily master

### DIFF
--- a/content/v3/activity/events/types.md
+++ b/content/v3/activity/events/types.md
@@ -40,7 +40,7 @@ ref
 : **string** - The git ref (or `null` if only a repository was created).
 
 master\_branch
-: **string** - The name of the repository's master branch.
+: **string** - The name of the repository's default branch (usually `master`).
 
 description
 : **string** - The repository's current description.

--- a/content/v3/repos/contents.md
+++ b/content/v3/repos/contents.md
@@ -21,7 +21,7 @@ READMEs support [a custom media type](#custom-media-types) for getting the raw c
 ### Parameters
 
 ref
-: _Optional_ **string** - The String name of the Commit/Branch/Tag.  Defaults to `master`.
+: _Optional_ **string** - The String name of the Commit/Branch/Tag. If not provided, uses the repository’s default branch (usually `master`).
 
 ### Response
 
@@ -48,7 +48,7 @@ path
 : _Optional_ **string** - The content path.
 
 ref
-: _Optional_ **string** - The String name of the Commit/Branch/Tag.  Defaults to `master`.
+: _Optional_ **string** - The String name of the Commit/Branch/Tag. If not provided, uses the repository’s default branch (usually `master`).
 
 ### Response if content is a file
 
@@ -97,13 +97,13 @@ content
 : _Required_ **string** - The new file content, Base64 encoded.
 
 branch
-: _Optional_ **string** - The branch name. If not provided, uses the repository's 
+: _Optional_ **string** - The branch name. If not provided, uses the repository's
 default branch (usually `master`).
 
 ### Optional Parameters
 
 The `author` section is optional and is filled in with the `committer`
-information if omitted. If the `committer` information is omitted, the authenticated 
+information if omitted. If the `committer` information is omitted, the authenticated
 user's information is used.
 
 You must provide values for both `name` and `email`, whether you choose to use
@@ -154,13 +154,13 @@ sha
 : _Required_ **string** - The blob SHA of the file being replaced.
 
 branch
-: _Optional_ **string** - The branch name. If not provided, uses the repository's 
+: _Optional_ **string** - The branch name. If not provided, uses the repository's
 default branch (usually `master`).
 
 ### Optional Parameters
 
 The `author` section is optional and is filled in with the `committer`
-information if omitted. If the `committer` information is omitted, the authenticated 
+information if omitted. If the `committer` information is omitted, the authenticated
 user's information is used.
 
 You must provide values for both `name` and `email`, whether you choose to use
@@ -209,13 +209,13 @@ sha
 : _Required_ **string** - The blob SHA of the file being removed.
 
 branch
-: _Optional_ **string** - The branch name. If not provided, uses the repository's 
+: _Optional_ **string** - The branch name. If not provided, uses the repository's
 default branch (usually `master`).
 
 ### Optional Parameters
 
 The `author` section is optional and is filled in with the `committer`
-information if omitted. If the `committer` information is omitted, the authenticated 
+information if omitted. If the `committer` information is omitted, the authenticated
 user's information is used.
 
 You must provide values for both `name` and `email`, whether you choose to use


### PR DESCRIPTION
In some places, the documentation states that the `master` branch is the default value that is used in case the branch/tag/commit is not defined. However, this is not the case -- the API defaults to whatever the default branch is (I checked these calls). Usually this is `master`, but not necessarily so. 

Also, applied some :scissors:-action to trailing whitespaces. 
