### PR TITLE
corrected search examples encoded urls.  The example states the wish is

### DIFF
--- a/content/v3/search.md
+++ b/content/v3/search.md
@@ -310,7 +310,7 @@ order
 
 Imagine you're looking for a list of popular users. You might try out this query:
 
-    https://api.github.com/search/users?q=tom+repos:%3A42+followers:%3A1000
+    https://api.github.com/search/users?q=tom+repos:%3E42+followers:%3E1000
 
 Here, we're looking at users with the name Tom. We're only interested in those
 with more than 42 repositories, and only if they have over 1,000 followers.
@@ -327,7 +327,7 @@ media type in your Accept header. For example, via curl, the above query would
 look like this:
 
     curl -H 'Accept: application/vnd.github.preview.text-match+json' \
-      https://api.github.com/search/users?q=tom+repos:%3A42+followers:%3A1000
+      https://api.github.com/search/users?q=tom+repos:%3E42+followers:%3E1000
 
 This produces the same JSON payload as above, with an extra key called
 `text_matches`, an array of objects. These objects provide information such as


### PR DESCRIPTION
to return users whom have more than 42 repos and more than 1000
followers, however the url does not return anything since it uses the
wrong encoded character.
