### PR TITLE
fix the link of nanoc tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ You can see the available commands with nanoc:
 
     nanoc -h
 
-Nanoc has [some nice documentation](http://nanoc.stoneship.org/docs/3-getting-started/) to get you started.  Though if you're mainly concerned with editing or adding content, you won't need to know much about nanoc.
+Nanoc has [some nice documentation](http://nanoc.ws/docs/tutorial/) to get you started.  Though if you're mainly concerned with editing or adding content, you won't need to know much about nanoc.
 
 [nanoc]: http://nanoc.stoneship.org/
 


### PR DESCRIPTION
the original link http://nanoc.ws/docs/3-getting-started/ is broken.
