### PR TITLE
Added `502 Bad Gateway` to the STATUSES hash.

### DIFF
--- a/lib/resources.rb
+++ b/lib/resources.rb
@@ -74,8 +74,10 @@ module GitHub
           end
         end
 
-        lines << "X-RateLimit-Limit: 5000" unless head.has_key?('X-RateLimit-Limit')
-        lines << "X-RateLimit-Remaining: 4999" unless head.has_key?('X-RateLimit-Remaining')
+        unless status == 502
+          lines << "X-RateLimit-Limit: 5000" unless head.has_key?('X-RateLimit-Limit')
+          lines << "X-RateLimit-Remaining: 4999" unless head.has_key?('X-RateLimit-Remaining')
+        end
 
         %(<pre class="#{css_class}"><code>#{lines * "\n"}</code></pre>\n)
       end


### PR DESCRIPTION
`502 Bad Gateway` is used in the case of upstream failure when uploading release assets.

The response was previously documented in fcaed8d4, however the STATUSES array wasn't updated to support this response.

Before:

![screen shot 2013-10-21 at 14 04 08](https://f.cloud.github.com/assets/65057/1372022/ef94385e-3a48-11e3-8c39-201ace4767b4.png)

After:

![screen shot 2013-10-21 at 14 05 17](https://f.cloud.github.com/assets/65057/1372028/133f69d6-3a49-11e3-8c01-f7010be00651.png)

@technoweenie 
