### PR TITLE
Link Issue events in /activity/events/

### DIFF
--- a/content/v3/activity/events.md
+++ b/content/v3/activity/events.md
@@ -46,6 +46,10 @@ All Events have the same response format:
 
 ## List issue events for a repository
 
+These are events that have occurred around Issues for a repository.
+They are returned in a format that is different from other events and
+that is documented in the [Issue Events API page](http://developer.github.com/v3/issues/events/#list-events-for-a-repository).
+
     GET /repos/:owner/:repo/issues/events
 
 ## List public events for a network of repositories


### PR DESCRIPTION
The [Activity Event documentation](http://developer.github.com/v3/activity/events) says:

```
All Events have the same response format
```

This is true for all Event endpoint **except one**:

```
GET /repos/:owner/:repo/issues/events
```

In fact, this endpoint returns the following fields: `id` (integer), `actor`, `commit_id`, `created_at`, `event`, `issue`, `url`, while all the other endpoints return the following fields: `id` (string), `type`, `actor`, `repo`, `payl

To avoid confusion, I suggest to _add a link_ to the Issue Events page
that has an example of the response format returned for Issue Events
