### PR TITLE
Thread IDs are Strings, not Integer

### DIFF
--- a/lib/resources.rb
+++ b/lib/resources.rb
@@ -1535,7 +1535,7 @@ module GitHub
     }
 
     THREAD = {
-      :id => 1,
+      :id => "1",
       :repository => SIMPLE_REPO,
       :subject => {
         :title => "Greetings",


### PR DESCRIPTION
The THREAD resource (used to document Notifications) states that the ID is returned as an Integer, where in fact is returned as a String.

For instance, if I run

```
curl -u [KEY]:x-oauth-basic https://api.github.com/notifications
```

I obtain the following result (truncated):

```
[
  {
    "id": "18765913",
    "unread": true,
    "reason": "mention",
    "updated_at": "2013-10-21T15:52:16Z",
    "last_read_at": null, ...
  }
]
```
