### PR TITLE
Update repo hooks documentation

### DIFF
--- a/content/v3/repos/hooks.md
+++ b/content/v3/repos/hooks.md
@@ -12,7 +12,7 @@ hooks for a repository.  Hooks can be managed using the [JSON HTTP API](#json-ht
 and the [PubSubHubbub API](#pubsubhubbub).
 
 Each hook can be configured for a specific [service](#services) and one or 
-more [event](#events), regardless of the API used to do so.
+more [events](#events), regardless of the API used to do so.
 
 ## Services
 


### PR DESCRIPTION
I ran into some confusion over the weekend thinking that the [web service should listen to all events by default](https://github.com/github/github-services/pull/712). @kdaigle suggested that I update the docs, and so I have.
## 

Clarify and expand hook documentation to explain the differences between a `service` and an `event`, each of which got a section header with links throughout. Provide details on service configuration settings, default events and supported events.
- Increase heading levels to support new sections
- Provide more linking throughout
- Add examples in the service and event sections
