### PR TITLE
Use :id, not 1, as a thread_id placeholder

### DIFF
--- a/content/v3/activity/notifications.md
+++ b/content/v3/activity/notifications.md
@@ -157,7 +157,7 @@ updated since this time will not be updated.  Default: Now.  Expected in ISO
 This checks to see if the current user is subscribed to a thread.  You can also
 [get a Repository subscription](/v3/activity/watching/#get-a-repository-subscription).
 
-    GET /notifications/threads/1/subscription
+    GET /notifications/threads/:id/subscription
 
 ### Response
 
@@ -171,7 +171,7 @@ is unnecessary if the user is already subscribed to the repository.  Ignoring
 a thread will mute all future notifications (until you comment or get
 @mentioned).
 
-    PUT /notifications/threads/1/subscription
+    PUT /notifications/threads/:id/subscription
 
 ### Input
 
@@ -190,7 +190,7 @@ thread.
 
 ## Delete a Thread Subscription
 
-    DELETE /notifications/threads/1/subscription
+    DELETE /notifications/threads/:id/subscription
 
 ### Response
 


### PR DESCRIPTION
Coherently with the rest of the documentation, there should not be hard-coded IDs in the example routes, but placeholders
