### PR TITLE
Fixed link in getting-started.md example

### DIFF
--- a/content/guides/getting-started.md
+++ b/content/guides/getting-started.md
@@ -208,7 +208,7 @@ Most any meaningful use of the GitHub API will involve some level of Repository
 information. We can `GET` repository details in the same way we fetched user
 details earlier:
 
-      curl -i https://github.com/twbs/bootstrap
+      curl -i https://api.github.com/repos/twbs/bootstrap
 
 In the same way, we can view repositories for the authenticated user:
 


### PR DESCRIPTION
Corrected twitter bootstrap repo link to:  https://github.com/twbs/bootstrap

The older url https://api.github.com/repos/twitter/bootstrap returned a 404 error and is not what getbootstrap.com is pointing to.
