### PR TITLE
Note that fetching lists of resources returns a reduced attribute set when compared to fetching a single resource

### DIFF
--- a/content/v3.md
+++ b/content/v3.md
@@ -44,18 +44,35 @@ All timestamps are returned in ISO 8601 format:
 
     YYYY-MM-DDTHH:MM:SSZ
 
-For performance reasons, fetching a list of resources may return a reduced set
-of attributes for each resource when compared to the attributes returned when
-fetching a single resource.
+### Summary Representations
 
-For example, when fetching
-[list of pull requests](http://developer.github.com/v3/pulls/#list-pull-requests),
-pull request descriptions do not include the `mergeable` attribute. However,
-this attribute is included in the description when a [single pull request is fetched](http://developer.github.com/v3/pulls/#get-a-single-pull-request).
+When you fetch a list of resources, the response includes a _subset_ of the
+attributes for that resource. This is the "summary" representation of the
+resource. (Some attributes are computationally expensive for the API to provide.
+For performance reasons, the summary representation excludes those attributes.
+To obtain those attributes, fetch the "detailed" representation.)
 
-Example responses given with each API endpoint list all attributes that are
-returned by that endpoint.
+**Example**: When you get a list of repositories, you get the summary
+representation of each repository. Here, we fetch the list of repositories owned
+by the [octokit](https://github.com/octokit) organization:
 
+    GET /orgs/octokit/repos
+
+### Detailed Representations
+
+When you fetch an individual resource, the response typically includes _all_
+attributes for that resource. This is the "detailed" representation of the
+resource. (Note that authorization sometimes influences the amount of detail
+included in the representation.)
+
+**Example**: When you get an individual repository, you get the detailed
+representation of the repository. Here, we fetch the
+[octokit/octokit.rb](https://github.com/octokit/octokit.rb) repository:
+
+    GET /repos/octokit/octokit.rb
+
+The documentation provides an example response for each API method. The example
+response illustrates all attributes that are returned by that method.
 
 ## Parameters
 


### PR DESCRIPTION
Taking a first stab of this, as discussed in this pull request: https://github.com/github/developer.github.com/pull/332#issuecomment-26710914. 

It could use some :heart: from @gjtorikian and :eyes: from @github/api. 
