### PR TITLE
Make the example match reality.

### DIFF
--- a/content/v3/repos/releases.md
+++ b/content/v3/repos/releases.md
@@ -131,7 +131,7 @@ prerelease. `false` to identify the release as a full release.
   :tag_name         => "v1.0.0",
   :target_commitish => "master",
   :name             => "v1.0.0",
-  :description      => "Description of the release",
+  :body             => "Description of the release",
   :draft            => false,
   :prerelease       => false
 %>


### PR DESCRIPTION
The 'create release' and 'update release' examples showed a `description` field instead of a `body` field.
