### PR TITLE
Templetize cURL examples that use usernames and tokens for authentication

### DIFF
--- a/content/v3/auth.md
+++ b/content/v3/auth.md
@@ -30,22 +30,23 @@ To use Basic Authentication with the GitHub API, simply send the username and
 password associated with the account.
 
 For example, if you're accessing the API via [cURL][curl], the following command
-would authenticate with `mojombo` as the username. (cURL will prompt you to
-enter the password.)
+would authenticate you if you replace `<username>` with your GitHub username.
+(cURL will prompt you to enter the password.)
 
 <pre class='terminal'>
-curl -u mojombo https://api.github.com/user
+curl -u <username> https://api.github.com/user
 </pre>
 
 ### Via OAuth Tokens
 
 Alternatively, you can authenticate using [personal access
 tokens][personal-access-tokens] or OAuth tokens. To do so, provide the token as
-the username and provide a blank password or a password of `x-oauth-basic`. For
-example:
+the username and provide a blank password or a password of `x-oauth-basic`. If
+you're accessing the API via cURL, replace `<token>` with your OAuth token in
+the following command:
 
 <pre class='terminal'>
-curl -u 3816d821c80a6847ca84550052c1ff6246e8169b:x-oauth-basic https://api.github.com/user
+curl -u <token>:x-oauth-basic https://api.github.com/user
 </pre>
 
 This approach is useful if your tools only support Basic Authentication but you


### PR DESCRIPTION
As mentioned in https://github.com/github/developer.github.com/pull/330, the curl examples in the [Authentication docs](http://developer.github.com/v3/auth/) might be misleading for some users.

For example, users shouldn't try to authenticate as mojombo because it will fail, and some users might think that the way to fix this is to modify the URL somehow (e.g. replace `user` with their username):

``` bash
$ curl -u mojombo https://api.github.com/user
```

Instead, I'd like to suggest a templetized approach to the curl command, like so:

``` bash
$ curl -u <username> https://api.github.com/user
```

Using `:username` as the format for templetizing might be confusing when not used in the URL. The second curl example in this page demonstrates this problem. So, this could be confusing:

``` bash
$ curl -u :token:x-oauth-basic https://api.github.com/user
```

but this probably won't be:

``` bash
$ curl -u <token>:x-oauth-basic https://api.github.com/user
```

cc @gjtorikian @jasonrudolph 
