### PR TITLE
Fixed formatting of curl commands

### DIFF
--- a/content/v3/auth.md
+++ b/content/v3/auth.md
@@ -33,9 +33,8 @@ For example, if you're accessing the API via [cURL][curl], the following command
 would authenticate you if you replace `<username>` with your GitHub username.
 (cURL will prompt you to enter the password.)
 
-<pre class='terminal'>
-curl -u <username> https://api.github.com/user
-</pre>
+    curl -u <username> https://api.github.com/user
+
 
 ### Via OAuth Tokens
 
@@ -45,9 +44,7 @@ the username and provide a blank password or a password of `x-oauth-basic`. If
 you're accessing the API via cURL, replace `<token>` with your OAuth token in
 the following command:
 
-<pre class='terminal'>
-curl -u <token>:x-oauth-basic https://api.github.com/user
-</pre>
+    curl -u <token>:x-oauth-basic https://api.github.com/user
 
 This approach is useful if your tools only support Basic Authentication but you
 want to take advantage of OAuth access token security features.


### PR DESCRIPTION
Use of `<pre>` with embedded `<username>` or `<token>` messed up the rendering (see http://developer.github.com/v3/auth/#working-with-two-factor-authentication)
