### PR TITLE
clarify that this is OAuth2

### DIFF
--- a/content/v3/oauth.md
+++ b/content/v3/oauth.md
@@ -20,7 +20,7 @@ and Client Secret. The Client Secret should not be shared.
 
 ## Web Application Flow
 
-This is a description of the OAuth flow from 3rd party web sites.
+This is a description of the OAuth2 flow from 3rd party web sites.
 
 ### 1. Redirect users to request GitHub access
 


### PR DESCRIPTION
Added a "2" to some locations to make it more obvious that this is OAuth2. This can help the reader choose the correct client/auth library and search for the right examples.
