### PR TITLE
master_branch is not always returned

### DIFF
--- a/lib/resources.rb
+++ b/lib/resources.rb
@@ -180,7 +180,6 @@ module GitHub
       "stargazers_count"  => 80,
       "watchers_count"    => 80,
       "size"              => 108,
-      "master_branch"     => 'master',
       "open_issues_count" => 0,
       "pushed_at"         => "2011-01-26T19:06:43Z",
       "created_at"        => "2011-01-26T19:01:12Z",


### PR DESCRIPTION
According to the [documentation](developer.github.com/v3/#detailed-representations):

```
The documentation provides an example response 
for each API method. The example response 
illustrates all attributes that are returned by 
that method.
```

Turns out that "master_branch" _is not_ an attribute that is always returned by the Repo methods. 

More specifically, if you create a brand new repo on GitHub and don't push anything, that repo shows up in feeds like `/user/subscriptions` and it does not have a `master_branch` field.

If you feel this is not a bug in the documentation, but in the API, then ignore this commit... indeed, in my opinion, the API should always return that field, but simply set it to null if there is no master branch
