### PR TITLE
Calls to upload release assets should be made using an HTTP client which supports SNI

### DIFF
--- a/content/v3/repos/releases.md
+++ b/content/v3/repos/releases.md
@@ -145,8 +145,12 @@ Users with push access to the repository can delete a release.
 
 ## Upload a release asset
 
-This is a unique endpoint.  The domain of the request changes from "api.github.com"
-to **"uploads.github.com"**.  The asset data is expected in its raw binary form,
+This is a unique endpoint. The domain of the request changes from "api.github.com"
+to **"uploads.github.com"**. You need to use an HTTP client which supports
+[SNI](http://en.wikipedia.org/wiki/Server_Name_Indication) to make calls to this
+endpoint.
+
+The asset data is expected in its raw binary form,
 instead of JSON.  Everything else about the endpoint is the same.  Pass your
 authentication exactly the same as the rest of the API.
 


### PR DESCRIPTION
Added a sentence to document that calls to upload release assets should be made with an HTTP client that supports [SNI](http://en.wikipedia.org/wiki/Server_Name_Indication).
