### PR TITLE
Link referenced APIs from Activity API index

### DIFF
--- a/content/v3/activity.md
+++ b/content/v3/activity.md
@@ -1,33 +1,39 @@
 ---
 title: Activity | GitHub API
 ---
-#Activity
+# Activity
 
 Serving up the 'social' in Social Coding™, the Activity APIs provide access to
 notifications, subscriptions, and timelines.
 
-## Notifications
+## [Notifications][]
 
-Notifications of new comments are delivered to users.  The Notifications API
-lets you view these notifications, and mark them as read.
+Notifications of new comments are delivered to users.  [The Notifications
+API][Notifications] lets you view these notifications and mark them as read.
 
-## Starring
+## [Starring][]
 
-Repository Starring is a feature that lets users bookmark repositories.  Stars
+[Repository Starring][Starring] is a feature that lets users bookmark repositories.  Stars
 are shown next to repositories to show an approximate level of interest.  Stars
 have no effect on notifications or the activity feed.
 
-## Watching
+## [Watching][]
 
-Watching a Repository registers the user to receive notifications on new
+[Watching a Repository][Watching] registers the user to receive notifications on new
 discussions, as well as events in the user's activity feed.
 
-## Events
+## [Events][]
 
-This is a read-only API of the events that power the various activity streams
-on GitHub.
+The [Events API][Events] is a read-only interface to all the [event
+types][types] that power the various activity streams on GitHub.
 
-## Feeds
+## [Feeds][]
 
-List of Atom feeds available for the authenticating user.
+List of [Atom feeds][Feeds] available for the authenticating user.
 
+[Notifications]: /v3/activity/notifications/
+[Starring]: /v3/activity/starring/
+[Watching]: /v3/activity/watching/
+[Events]: /v3/activity/events/
+[types]: /v3/activity/events/types/
+[Feeds]: /v3/activity/feeds/


### PR DESCRIPTION
I often land on the Activity API index and then have to hunt for a link to one of the APIs in the sidebar. We should just link to the APIs in the page copy.

![screen shot 2013-11-13 at 4 43 49 pm](https://f.cloud.github.com/assets/865/1536602/2228b9c4-4cb5-11e3-864a-3b46171eccb1.png)

I'd be happy to add a CSS change to avoid the blue headings if desired.

@gjtorikian @tobiasahlin 
