### PR TITLE
Fix default value of type parameter when listing user repos to match reality

### DIFF
--- a/content/v3/repos.md
+++ b/content/v3/repos.md
@@ -36,7 +36,7 @@ List public repositories for the specified user.
 
 Name | Type | Description 
 -----|------|-------------
-`type`|`string` | Can be one of `all`, `owner`, `member`. Default: `all`
+`type`|`string` | Can be one of `all`, `owner`, `member`. Default: `owner`
 `sort`|`string` | Can be one of `created`, `updated`, `pushed`, `full_name`. Default: `full_name`
 `direction`|`string` | Can be one of `asc` or `desc`. Default: when using `full_name`: `asc`, otherwise `desc`
 


### PR DESCRIPTION
Currently, the docs say that `all` is being used as the default value for the `type` parameter when making a call to `/users/:user/repos`. However, the reality is that `owner` is being used as the default value, so this change updates the docs to reflect that.
