### PR TITLE
Parameter for filtering repository issues by milestone is called milestone

### DIFF
--- a/content/v3/issues.md
+++ b/content/v3/issues.md
@@ -50,7 +50,7 @@ Name | Type | Description
 
 Name | Type | Description 
 -----|------|--------------
-`filter`|`integer` or `string`| If an `integer` is passed, it should refer to a milestone number. If the string `*` is passed, issues with any milestone are accepted. If the string `none` is passed, issues without milestones are returned. Default: `*`
+`milestone`|`integer` or `string`| If an `integer` is passed, it should refer to a milestone number. If the string `*` is passed, issues with any milestone are accepted. If the string `none` is passed, issues without milestones are returned. Default: `*`
 `state`|`string`| Indicates the state of the issues to return. Can be either `open` or `closed`. Default: `open`
 `assignee`|`string`| Can be the name of a user. Pass in `none` for issues with no assigned user, and `*` for issues assigned to any user. Default: `*`
 `creator`|`string`| The user that created the issue.


### PR DESCRIPTION
The parameter for filtering repository issues by milestone is called `milestone`, not `filter`. I believe this was unintentionally changed in [this commit here](https://github.com/github/developer.github.com/commit/3aa7c72d9b667fd74a1ce1ff67990aab26906750#diff-8bbb992226a6e795d4477570fd73cbb9R53).

cc @gjtorikian 

Thanks for the report @leandro-lucarella-sociomantic!
