### PR TITLE
VERSION -> v3 in /content/v3/repos/contents.md

### DIFF
--- a/content/v3/repos/contents.md
+++ b/content/v3/repos/contents.md
@@ -270,6 +270,6 @@ curl -L https://api.github.com/repos/pengwynn/octokit/tarball > octokit.tar.gz
 
 [READMEs](#get-the-readme), [files](#get-contents), and [symlinks](#get-contents) support the following custom media type.
 
-    application/vnd.github.VERSION.raw
+    application/vnd.github.v3.raw
 
 You can read more about the use of media types in the API [here](/v3/media/).


### PR DESCRIPTION
I could be wrong here, perhaps the literal string `VERSION` is supposed to be here but the api definitely works with `application/vnd.github.v3.raw` and that seems to make more sense.
