### PR TITLE
"Third-party libraries" list headers no longer cover first library

### DIFF
--- a/static/shared/css/documentation.css
+++ b/static/shared/css/documentation.css
@@ -127,6 +127,7 @@ h2 {
 	margin-bottom: -17px;
 	margin-left: 0px;
 	font-size: 16px;
+	width: 200px;
 }
 
 .library-list ul {


### PR DESCRIPTION
This was preventing users from clicking on the first listed library. The solution was to reduce the headers' widths to that of the list items' offsets.
