### PR TITLE
updates hook docs with new hooks

### DIFF
--- a/content/v3/repos/hooks.md
+++ b/content/v3/repos/hooks.md
@@ -62,9 +62,6 @@ Name | Description
 `commit_comment` | Any time a Commit is commented on.
 `create` | Any time a Repository, Branch or Tag is created
 `delete` | Any time a Branch or Tag is deleted
-`follow` | Any time a user follows another user
-`fork_apply` | Any time a patch is applied in the Fork Queue
-`gist` | Any time a gist is created or updated
 `pull_request` | Any time a Pull Request is opened, closed, or synchronized (updated due to a new push in the branch that the pull request is tracking).
 `pull_request_review_comment` | Any time a Commit is commented on while inside a Pull Request review (the Files Changed tab).
 `gollum` | Any time a Wiki page is updated.


### PR DESCRIPTION
Does what it says. I reconciled `content/v3/repos/hooks.md` with `/v3/activity/events/types/` . The latter had more hooks and my experience indicated it was more up to date.
