### PR TITLE
Clarify verifiable_password_authentication's description

### DIFF
--- a/content/v3/meta.md
+++ b/content/v3/meta.md
@@ -19,4 +19,4 @@ Name | Type | Description
 -----|------|--------------
 `hooks`|`array` of `strings` | An Array of IP addresses in CIDR format specifying the addresses that incoming service hooks will originate from on GitHub.com.  Subscribe to the [API Changes blog](http://developer.github.com/changes/) or follow [@GitHubAPI](https://twitter.com/GitHubAPI) on Twitter to get updated when this list changes.
 `git`|`array` of `strings` | An Array of IP addresses in CIDR format specifying the Git servers for GitHub.com.
-`verifiable_password_authentication`|`boolean` | Whether [Basic Authentication](/v3/auth/#basic-authentication) is supported. Some [GitHub Enterprise](https://enterprise.github.com/) servers may return `false` here.
+`verifiable_password_authentication`|`boolean` | Whether [Basic Authentication with a username and password](/v3/auth/#via-username-and-password) is supported. Some [GitHub Enterprise](https://enterprise.github.com/) servers may return `false` here.


### PR DESCRIPTION
As noted by @jasonrudolph in #377, this flag only describes whether _password_ login works over basic auth.
