### PR TITLE
Add the error code for missing user agent

### DIFF
--- a/content/v3.md
+++ b/content/v3.md
@@ -386,10 +386,14 @@ Here's an example:
 User-Agent: Awesome-Octocat-App
 </pre>
 
-The error without an user agent looks like this:
+If you provide an invalid `User-Agent` header, you will receive a `403 Forbidden` response:
 
 <pre class="terminal">
-Status: 403 Forbidden
+curl -iH 'User-Agent: ' https://api.github.com/meta
+HTTP/1.0 403 Forbidden
+Connection: close
+Content-Type: text/html
+
 Request forbidden by administrative rules.
 Please make sure your request has a User-Agent header.
 Check https://developer.github.com for other possible causes.


### PR DESCRIPTION
This requirement is somewhat _hidden_ in the documentation.
Besides that still residing problem, the pull allows to:
- google the problem
- adds what the `Status 403: Forbidden` could be caused by

The problem for e.g. PHP's cURL is, that the [user agent is not set by default](https://github.com/ax3l/github_status_proxy/commit/4d3b205b467fbc260eb2735e80b09e31b504b9e7).

Example:

``` php
$ch = curl_init();
...
curl_setopt($ch, CURLOPT_USERAGENT, "Awesome-Octocat-App");
...
```
