### PR TITLE
Move notices about events that are no longer generated from payload details to main description

### DIFF
--- a/content/v3/activity/events/types.md
+++ b/content/v3/activity/events/types.md
@@ -70,13 +70,13 @@ Key | Type | Description
 
 Triggered when a new [download](/v3/repos/downloads/) is created.
 
+Events of this type are **no longer created**, but it's possible that they exist in timelines of some users.
+
 ### Hook name
 
 `download`
 
 ### Payload
-
-Events of this type are **no longer created**, but it's possible that they exist in timelines of some users.
 
 Key | Type | Description
 ----|------|-------------
@@ -136,13 +136,13 @@ Key | Type | Description
 
 Triggered when a [Gist](/v3/gists/) is created or updated.
 
+Events of this type are **no longer created**, but it's possible that they exist in timelines of some users.
+
 ### Hook name
 
 `gist`
 
 ### Payload
-
-Events of this type are **no longer created**, but it's possible that they exist in timelines of some users.
 
 Key | Type | Description
 ----|------|-------------


### PR DESCRIPTION
It looks like that these descriptions about events that are no longer being generated got moved to the payload part at some point. This pull request moves them back to where they should be, and where they're more visible.
