### PR TITLE
Deprecate Downloads API

### DIFF
--- a/content/v3.md
+++ b/content/v3.md
@@ -551,15 +551,6 @@ The recommendations below will help you prepare your application for the next ma
 1. Method: /repos/:owner/:repo/hooks/:id/test
 : Recommendation: Use **/repos/:owner/:repo/hooks/:id/tests** (plural) instead.
 
-1. Method: /repos/:owner/:repo/downloads
-: Recommendation: Use [Releases API](/v3/repos/releases) instead.
-
-1. Method: GET /repos/:owner/:repo/downloads/:id
-: Recommendation: Use [Releases API](/v3/repos/releases) instead.
-
-1. Method: DELETE /repos/:owner/:repo/downloads/:id
-: Recommendation: Use [Releases API](/v3/repos/releases) instead.
-
 1. Query parameters when POSTing to /repos/:owner/:repo/forks
 : Recommendation: Use JSON to POST to this method instead.
 

--- a/content/v3/repos/downloads.md
+++ b/content/v3/repos/downloads.md
@@ -11,8 +11,9 @@ title: Downloads | GitHub API
 
 <div class="alert">
   <p>
-    The Downloads API (described below) is <a href="/v3/#deprecations">deprecated</a>
-    and is scheduled for removal in the next version of the API.
+    The Downloads API (described below) was
+    <a href="https://github.com/blog/1302-goodbye-uploads">deprecated on December 11, 2012</a>.
+    It will be removed at a future date.
 
     We recommend using <a href="/v3/repos/releases/">Releases</a> instead.
   </p>


### PR DESCRIPTION
The [Downloads API](http://developer.github.com/v3/repos/downloads/) has been officially deprecated since we said "[Goodbye, Uploads](https://github.com/blog/1302-goodbye-uploads)".

This adds documentation for that deprecation.

An alert has been added to the Downloads API page:

![screen shot 2013-12-05 at 16 54 30](https://f.cloud.github.com/assets/65057/1684030/b58c9e6c-5dc5-11e3-8d65-ed5f88c931b8.png)

And the appropriate deprecations have been added to the Deprecations list:

![screen shot 2013-12-05 at 16 55 21](https://f.cloud.github.com/assets/65057/1684034/bbe4c122-5dc5-11e3-967f-df83980245e3.png)

Related to this, today I also updated the [blog post](https://github.com/blog/1302-goodbye-uploads) announcing this deprecation, to change the originally planned "disabled in 90 days" to "disabled at a future date".

![screen shot 2013-12-05 at 16 58 10](https://f.cloud.github.com/assets/65057/1684064/156c854a-5dc6-11e3-84b5-cbd0f5a23b54.png)
