### PR TITLE
Set up proper ratelimit headers

### DIFF
--- a/content/v3/search.md
+++ b/content/v3/search.md
@@ -75,7 +75,7 @@ repositories where the primary language is Assembly. We're sorting by stars in
 descending order, so that the most popular repositories appear first in the
 search results.
 
-<%= headers 200, {'X-RateLimit-Limit' => 5, 'X-RateLimit-Remaining' => 4} %>
+<%= headers 200, {'X-RateLimit-Limit' => 20, 'X-RateLimit-Remaining' => 19} %>
 <%= json(:repo_search_v3_results) %>
 
 ### Highlighting Repository Search Results
@@ -148,7 +148,7 @@ Here, we're searching for the keyword `addClass` within a file's contents. We're
 making sure that we're only looking in files where the language is JavaScript.
 And we're scoping the search to the `repo:jquery/jquery` repository.
 
-<%= headers 200, {'X-RateLimit-Limit' => 5, 'X-RateLimit-Remaining' => 4} %>
+<%= headers 200, {'X-RateLimit-Limit' => 20, 'X-RateLimit-Remaining' => 19} %>
 <%= json(:code_search_v3_results) %>
 
 ### Highlighting Code Search Results
@@ -233,7 +233,7 @@ that's labeled as `bug`. The search runs across repositories whose primary
 language is Python. We’re sorting by creation date in ascending order, so that
 the oldest issues appear first in the search results.
 
-<%= headers 200, {'X-RateLimit-Limit' => 5, 'X-RateLimit-Remaining' => 4} %>
+<%= headers 200, {'X-RateLimit-Limit' => 20, 'X-RateLimit-Remaining' => 19} %>
 <%= json(:issue_search_v3_results) %>
 
 ### Highlighting Issue Search Results
@@ -303,7 +303,7 @@ Imagine you're looking for a list of popular users. You might try out this query
 Here, we're looking at users with the name Tom. We're only interested in those
 with more than 42 repositories, and only if they have over 1,000 followers.
 
-<%= headers 200, {'X-RateLimit-Limit' => 5, 'X-RateLimit-Remaining' => 4} %>
+<%= headers 200, {'X-RateLimit-Limit' => 20, 'X-RateLimit-Remaining' => 19} %>
 <%= json(:user_search_v3_results) %>
 
 ### Highlighting User Search Results


### PR DESCRIPTION
While reviewing the new Search API's docs, I noticed that the ratelimit headers returned for example responses were not correct.
