### PR TITLE
Include gist counts in v3 user JSON

### DIFF
--- a/content/v3/users.md
+++ b/content/v3/users.md
@@ -25,12 +25,6 @@ information](/v3/#authentication) with your request).
 Note: The returned email is the user's publicly visible email address
 (or `null` if the user has not [specified a public email address in their profile](https://github.com/settings/profile)).
 
-<div class="alert">
-  <p>
-    <strong>Note</strong>: When using the <a href="/v3/media/#beta-v3-and-the-future">v3 media type</a>, the response omits the <code>public_gists</code> attribute.
-  </p>
-</div>
-
 ## Get the authenticated user
 
     GET /user
@@ -39,12 +33,6 @@ Note: The returned email is the user's publicly visible email address
 
 <%= headers 200 %>
 <%= json :private_user %>
-
-<div class="alert">
-  <p>
-    <strong>Note</strong>: When using the <a href="/v3/media/#beta-v3-and-the-future">v3 media type</a>, the response omits the <code>public_gists</code> and <code>private_gists</code> attributes.
-  </p>
-</div>
 
 ## Update the authenticated user
 

--- a/content/v3/versions.md
+++ b/content/v3/versions.md
@@ -29,10 +29,6 @@ When an [issue](/v3/issues/#get-a-single-issue) is not a pull request, the v3 me
 
 For [Repositories](/v3/repos/#get), the v3 media type omits the `master_branch` attribute. API clients should use the `default_branch` attribute to obtain the repository's default branch.
 
-### User JSON
-
-For [Users](/v3/users/), the v3 media type omits the `public_gists` and `private_gists` attributes.
-
 ### User Emails JSON
 
 For [User Emails](/v3/users/emails/#list-email-addresses-for-a-user), the v3 media type returns an array of hashes (instead of an array of strings).


### PR DESCRIPTION
The JSON representation for a user is now the **same** between the beta media type and the v3 media type. This pull request updates the docs accordingly.
