### PR TITLE
In prose, use "repository" instead of "repo"

### DIFF
--- a/content/changes/2012-12-08-finding-source-and-fork-repos-for-organizations.html
+++ b/content/changes/2012-12-08-finding-source-and-fork-repos-for-organizations.html
@@ -8,7 +8,7 @@ author_name: rick
 We've made a couple of changes today to the Organization repositories
 listing to bring it a bit closer to the functionality of the GitHub.com
 Organization repositories tab.  We now let you retrieve repositories
-which are forks of another repo, as well as those repositories which
+which are forks of another repository, as well as those repositories which
 are sources (not forks).
 
     # Grab all fork Repositories for an Organization

--- a/content/guides/index.md
+++ b/content/guides/index.md
@@ -11,7 +11,7 @@ authentication, to manipulating results, to combining results with other service
 
 Every tutorial here will have a project, and every project will be
 stored and documented in our public
-[platform-samples](https://github.com/github/platform-samples) repo.
+[platform-samples](https://github.com/github/platform-samples) repository.
 
 Feel free to fork, clone, and improve these guides.
 

--- a/content/v3/activity/events/types.md
+++ b/content/v3/activity/events/types.md
@@ -128,8 +128,8 @@ Events of this type are **no longer created**, but it's possible that they exist
 Key | Type | Description
 ----|------|-------------
 `head`|`string` | The branch name the patch is applied to.
-`before`|`string` | SHA of the repo state before the patch.
-`after`|`string` | SHA of the repo state after the patch.
+`before`|`string` | SHA of the repository state before the patch.
+`after`|`string` | SHA of the repository state after the patch.
 
 
 ## GistEvent
@@ -348,7 +348,7 @@ The WatchEvent is related to [starring a repository](/v3/activity/starring/#star
 See [this API blog post](/changes/2012-9-5-watcher-api/) for an explanation.
 
 The event’s actor is the [user](/v3/users/) who starred a repository, and the
-event’s repo is the [repository](/v3/repos/) that was starred.
+event’s repository is the [repository](/v3/repos/) that was starred.
 
 ### Hook name
 

--- a/content/v3/git.md
+++ b/content/v3/git.md
@@ -13,7 +13,7 @@ our API - by creating raw objects directly into the database and updating
 branch references you could technically do just about anything that Git
 can do without having Git installed.
 
-Git DB API functions will return a `409 Conflict` if the git repo for a Repository is empty
+Git DB API functions will return a `409 Conflict` if the git repository for a Repository is empty
 or unavailable.  This typically means it is being created still.  [Contact
 Support](https://github.com/contact?form[subject]=Commits API) if this response status persists.
 

--- a/content/v3/orgs/teams.md
+++ b/content/v3/orgs/teams.md
@@ -165,23 +165,23 @@ NOTE: This does not delete the user, it just remove them from the team.
 <%= headers 200 %>
 <%= json(:repo) { |h| [h] } %>
 
-## Check if a team manages a repo {#get-team-repo}
+## Check if a team manages a repository {#get-team-repo}
 
     GET /teams/:id/repos/:owner/:repo
 
-### Response if repo is managed by this team
+### Response if repository is managed by this team
 
 <%= headers 204 %>
 
-### Response if repo is not managed by this team
+### Response if repository is not managed by this team
 
 <%= headers 404 %>
 
-## Add team repo
+## Add team repository {#add-team-repo}
 
-In order to add a repo to a team, the authenticated user must be an
-owner of the org that the team is associated with.  Also, the repo must
-be owned by the organization, or a direct fork of a repo owned by the
+In order to add a repository to a team, the authenticated user must be an
+owner of the org that the team is associated with.  Also, the repository must
+be owned by the organization, or a direct fork of a repository owned by the
 organization.
 
     PUT /teams/:id/repos/:org/:repo
@@ -190,7 +190,7 @@ organization.
 
 <%= headers 204 %>
 
-If you attempt to add a repo to a team that is not owned by the
+If you attempt to add a repository to a team that is not owned by the
 organization, you get:
 
 <%= headers 422 %>
@@ -202,11 +202,11 @@ organization, you get:
       :resource => :TeamMember}]
 %>
 
-## Remove team repo
+## Remove team repository {#remove-team-repo}
 
-In order to remove a repo from a team, the authenticated user must be an
+In order to remove a repository from a team, the authenticated user must be an
 owner of the org that the team is associated with.
-NOTE: This does not delete the repo, it just removes it from the team.
+NOTE: This does not delete the repository, it just removes it from the team.
 
     DELETE /teams/:id/repos/:owner/:repo
 

--- a/content/v3/pulls.md
+++ b/content/v3/pulls.md
@@ -78,7 +78,7 @@ Name | Type | Description
 -----|------|-------------
 `title`|`string` | **Required**. The title of the pull request.
 `head`|`string` | **Required**. The branch (or git ref) where your changes are implemented.
-`base`|`string` | **Required**. The branch (or git ref) you want your changes pulled into. This should be an existing branch on the current repository. You cannot submit a pull request to one repo that requests a merge to a base of another repo.
+`base`|`string` | **Required**. The branch (or git ref) you want your changes pulled into. This should be an existing branch on the current repository. You cannot submit a pull request to one repository that requests a merge to a base of another repository.
 `body`|`string` | The contents of the pull request.
 
 

--- a/content/v3/repos.md
+++ b/content/v3/repos.md
@@ -110,7 +110,7 @@ Name | Type | Description
 `has_issues`|`boolean` | Either `true` to enable issues for this repository, `false` to disable them. Default: `true`
 `has_wiki`|`boolean` | Either `true` to enable the wiki for this repository, `false` to disable it. Default: `true`
 `has_downloads`|`boolean` | Either `true` to enable downloads for this repository, `false` to disable them. Default: `true`
-`team_id`|`number` | The id of the team that will be granted access to this repository. This is only valid when creating a repo in an organization.
+`team_id`|`number` | The id of the team that will be granted access to this repository. This is only valid when creating a repository in an organization.
 `auto_init`|`boolean` | Pass `true` to create an initial commit with empty README. Default: `false`
 `gitignore_template`|`string` | Desired language or platform [.gitignore template](https://github.com/github/gitignore) to apply. Use the name of the template without the extension. For example, "Haskell". _Ignored if the `auto_init` parameter is not provided._
 
@@ -118,7 +118,7 @@ Name | Type | Description
 
 <%= json \
   :name          => "Hello-World",
-  :description   => "This is your first repo",
+  :description   => "This is your first repository",
   :homepage      => "https://github.com",
   :private       => false,
   :has_issues    => true,
@@ -139,8 +139,8 @@ Name | Type | Description
 
 ### Response
 
-The `parent` and `source` objects are present when the repo is a fork.
-`parent` is the repo this repo was forked from,
+The `parent` and `source` objects are present when the repository is a fork.
+`parent` is the repository this repository was forked from,
 `source` is the ultimate source for the network.
 
 <div class="alert">
@@ -173,7 +173,7 @@ Name | Type | Description
 
 <%= json \
   :name          => "Hello-World",
-  :description   => "This is your first repo",
+  :description   => "This is your first repository",
   :homepage      => "https://github.com",
   :private       => true,
   :has_issues    => true,

--- a/content/v3/repos/hooks.md
+++ b/content/v3/repos/hooks.md
@@ -113,7 +113,7 @@ The JSON HTTP API follows the same conventions as the rest of the
 Name | Type | Description 
 -----|------|--------------
 `name`|`string` | **Required**. The name of the service that is being called. (See [/hooks](https://api.github.com/hooks) for the list of valid hook names.)
-`config`|`hash` | **Required**. Key/value pairs to provide settings for this hook.  These settings vary between the services and are defined in the [github-services](https://github.com/github/github-services) repo. Booleans are stored internally as "1" for true, and "0" for false.  Any JSON `true`/`false` values will be converted automatically.
+`config`|`hash` | **Required**. Key/value pairs to provide settings for this hook.  These settings vary between the services and are defined in the [github-services](https://github.com/github/github-services) repository. Booleans are stored internally as "1" for true, and "0" for false.  Any JSON `true`/`false` values will be converted automatically.
 `events`|`array` | Determines what events the hook is triggered for.  Default: `["push"]`
 `active`|`boolean` | Determines whether the hook is actually triggered on pushes.
 
@@ -152,7 +152,7 @@ Here's how you can setup a hook that posts raw JSON
 
 Name | Type | Description 
 -----|------|--------------
-`config`|`hash` | Key/value pairs to provide settings for this hook.  Modifying this will replace the entire config object.  These settings vary between the services and are defined in the [github-services](https://github.com/github/github-services) repo. Booleans are stored internally as "1" for true, and "0" for false.  Any JSON `true`/`false` values will be converted automatically.
+`config`|`hash` | Key/value pairs to provide settings for this hook.  Modifying this will replace the entire config object.  These settings vary between the services and are defined in the [github-services](https://github.com/github/github-services) repository. Booleans are stored internally as "1" for true, and "0" for false.  Any JSON `true`/`false` values will be converted automatically.
 `events`|`array` | Determines what events the hook is triggered for.  This replaces the entire array of events.  Default: `["push"]`
 `add_events`|`array` | Determines a list of events to be added to the list of events that the Hook triggers for.
 `remove_events`|`array` | Determines a list of events to be removed from the list of events that the Hook triggers for.

--- a/content/v3/repos/statistics.md
+++ b/content/v3/repos/statistics.md
@@ -22,7 +22,7 @@ then submit the request again. If the job has completed, that request will recei
 Repository statistics are cached by the SHA of the repository's default branch,
 which is usually master; pushing to the default branch resets the statistics cache.
 
-## Get contributors list with additions, deletions, and commit counts
+## Get contributors list with additions, deletions, and commit counts {#contributors}
 
     GET /repos/:owner/:repo/stats/contributors
 
@@ -53,7 +53,7 @@ is a group of commits per day, starting on `Sunday`.
 <%= headers 200 %>
 <%= json(:repo_stats_commit_activity) %>
 
-## Get the number of additions and deletions per week
+## Get the number of additions and deletions per week {#code-frequency}
 
     GET /repos/:owner/:repo/stats/code_frequency
 
@@ -65,7 +65,7 @@ to a repository.
 <%= headers 200 %>
 <%= json(:repo_stats_code_frequency) %>
 
-## Get the weekly commit count for the repo owner and everyone else
+## Get the weekly commit count for the repository owner and everyone else {#participation}
 
     GET /repos/:owner/:repo/stats/participation
 
@@ -80,7 +80,7 @@ The array order is oldest week (index 0) to most recent week.
 <%= headers 200 %>
 <%= json(:repo_stats_participation) %>
 
-## Get the number of commits per hour in each day
+## Get the number of commits per hour in each day {#punch-card}
 
     GET /repos/:owner/:repo/stats/punch_card
 

--- a/content/v3/repos/statuses.md
+++ b/content/v3/repos/statuses.md
@@ -22,7 +22,7 @@ services to mark commits as passing or failing builds using Status.  The
 build.
 
 Note that the `repo:status` [OAuth scope](/v3/oauth/#scopes) grants targeted
-access to Statuses **without** also granting access to repo code, while the
+access to Statuses **without** also granting access to repository code, while the
 `repo` scope grants permission to code as well as statuses.
 
 ## List Statuses for a specific Ref


### PR DESCRIPTION
Some copy tweaks to make the prose less jargon-y. I _think_ I've kept any named anchors intact, except for a few which I shortened due to length.

/cc @izuzak @jdennes @gjtorikian 
