### PR TITLE
Use the correct ssl_version parameter

### DIFF
--- a/content/v3/troubleshooting.md
+++ b/content/v3/troubleshooting.md
@@ -47,4 +47,4 @@ dreams with the current rate limit (but don't worry, we'll help you out).
 
 When we send events to your server, we attempt to negotiate either SSL version 2 or 3.
 If your server requires a specific SSL version and does not support SSL negotiation,
-you can specify a specific version within the [WebHook's config block](http://developer.github.com/v3/repos/hooks/#edit-a-hook). Include a parameter called `ssl`, with a value of either `2` or `3`.
+you can specify a specific version within the [WebHook's config block](http://developer.github.com/v3/repos/hooks/#edit-a-hook). Include a parameter called `ssl_version`, with a value of either `2` or `3`.


### PR DESCRIPTION
It appears the troubleshooting documentation incorrectly specifies the `ssl` parameter within the config block where it should be `ssl_version` as used by the [webhook service](https://github.com/github/github-services/blob/master/lib/services/web.rb).
