### PR TITLE
Remove first person singular from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,15 @@
 
 This is a GitHub API resource built with [nanoc][nanoc].
 
-All submissions are welcome. To submit a change, fork this repo, commit your changes, and send us a [pull request](http://help.github.com/send-pull-requests/).
+All submissions are welcome. To submit a change, fork this repo, 
+commit your changes, and send us a 
+[pull request](http://help.github.com/send-pull-requests/).
 
 ## Setup
 
 Ruby 1.9 is required to build the site.
 
-Get the nanoc gem, plus kramdown for markdown parsing:
+Get the nanoc gem, plus kramdown for Markdown parsing:
 
 ```sh
 $ bundle install
@@ -20,7 +22,9 @@ You can see the available commands with nanoc:
 $ bundle exec nanoc -h
 ```
 
-Nanoc has [some nice documentation](http://nanoc.ws/docs/tutorial/) to get you started.  Though if you're mainly concerned with editing or adding content, you won't need to know much about nanoc.
+Nanoc has [some nice documentation](http://nanoc.ws/docs/tutorial/) 
+to get you started. Though if you're mainly concerned with editing 
+or adding content, you won't need to know much about nanoc.
 
 [nanoc]: http://nanoc.stoneship.org/
 
@@ -55,11 +59,13 @@ API docs should look like:
     <%= headers 200, :pagination => true, 'X-Custom-Header' => "value" %>
     <%= json :resource_name %>
 
-**Note**: We're using [Kramdown Markdown extensions](http://kramdown.rubyforge.org/syntax.html), such as definition lists.
+**Note**: We're using 
+[Kramdown Markdown extensions](http://kramdown.rubyforge.org/syntax.html), 
+such as definition lists.
 
 ### JSON Responses
 
-We specify the JSON responses in ruby so that we don't have to write
+We specify the JSON responses in Ruby so that we don't have to write
 them by hand all over the docs.  You can render the JSON for a resource
 like this:
 
@@ -77,8 +83,8 @@ Some actions return arrays.  You can modify the JSON by passing a block:
 
 ### Terminal blocks
 
-You can specify terminal blocks with `pre.terminal` elements.  It'd be
-nice if Markdown could do this more cleanly...
+You can specify terminal blocks with `pre.terminal` elements.  
+(It'd be nice if Markdown could do this more cleanly.)
 
 ```html
 <pre class="terminal">
@@ -87,7 +93,7 @@ $ curl foobar
 </pre>
 ```
 
-This isn't a `curl` tutorial though, I'm not sure every API call needs
+This is not a `curl` tutorial though. Not every API call needs
 to show how to access it with `curl`.
 
 ## Development
@@ -116,8 +122,8 @@ Compiling site...
 Site compiled in 5.81s.
 ```
 
-You can setup whatever you want to view the files.  If you have the adsf
-gem, however (I hope so, it was in the Gemfile), you can start Webrick:
+You can setup whatever you want to view the files. If using the adsf
+gem (as listed in the Gemfile), you can start Webrick:
 
 ```sh
 $ bundle exec nanoc view


### PR DESCRIPTION
Constrains lines to no more than around 70 characters.

Fixes spelling on capitals for Ruby, Markdown.
