### PR TITLE
/issues retrieves issues assigned to auth user

### DIFF
--- a/content/v3/issues.md
+++ b/content/v3/issues.md
@@ -12,7 +12,7 @@ read more about the use of media types in the API [here](/v3/media/).
 
 ## List issues
 
-List all issues across all the authenticated user's visible repositories
+List all issues assigned to the authenticated user across all visible repositories
 including owned repositories, member repositories, and organization
 repositories:
 


### PR DESCRIPTION
Also /user/issues does not return any results, do you know if this behavior is deprecated or if it has not been implemented yet?
