### PR TITLE
Clarify response for Repository Subscription

### DIFF
--- a/content/v3/activity/watching.md
+++ b/content/v3/activity/watching.md
@@ -51,10 +51,14 @@ List repositories being watched by the authenticated user.
 
     GET /repos/:owner/:repo/subscription
 
-### Response
+### Response if you are subscribed to the repository
 
 <%= headers 200 %>
 <%= json :repo_subscription %>
+
+### Response if you are not subscribed to the repository
+
+<%= headers 404 %>
 
 ## Set a Repository Subscription
 


### PR DESCRIPTION
I thought the response for getting a repository subscription might be json similar to the successful response with `subscribed: false` or the like but it actually returns 404 since there isn't one which would make sense to most people but not me.
