### PR TITLE
Add a note about the Status API list order

### DIFF
--- a/content/v3/repos/statuses.md
+++ b/content/v3/repos/statuses.md
@@ -31,6 +31,9 @@ Users with pull access can view commit statuses for a given ref:
 
     GET /repos/:owner/:repo/statuses/:ref
 
+Statuses are returned in reverse chronological order. The first status in the
+list will be the latest one.
+
 ### Parameters
 
 Name | Type | Description 


### PR DESCRIPTION
Since a commit can have multiple statuses recorded, it's pretty important for a client to know which one to consider to determine the overall "passing" state.
