### PR TITLE
Make code blocks inherit colors

### DIFF
--- a/static/shared/css/documentation.css
+++ b/static/shared/css/documentation.css
@@ -1018,7 +1018,6 @@ div.sidebar-module ul ul li span {
 .content ul code,
 p code {
   font: 12px Monaco,"Courier New","DejaVu Sans Mono","Bitstream Vera Sans Mono",monospace;
-  color: #52595d;
   -webkit-border-radius: 3px;
   -moz-border-radius: 3px;
   border-radius: 3px;
@@ -1031,9 +1030,6 @@ p code {
   display: inline-block;
 }
 
-.content a code {
-  color: #4183C4;
-}
 .content .sectionbody .dlist dt {
   margin-top: 10px;
 }


### PR DESCRIPTION
Fixes colors not being consistent in code blocks, by removing explicit color definitions for code blocks.

Before:
![screen shot 2014-01-27 at 14 45 47](https://f.cloud.github.com/assets/211284/2009153/bc6f4d0c-8759-11e3-86ac-5343372529d8.png)

After:
![screen shot 2014-01-27 at 14 45 33](https://f.cloud.github.com/assets/211284/2009156/bf937620-8759-11e3-8358-2f67e404409a.png)
