### PR TITLE
Update the parsing of JSON-P callback example

### DIFF
--- a/content/v3.md
+++ b/content/v3.md
@@ -535,28 +535,27 @@ $ curl https://api.github.com?callback=foo
 
 You can write a JavaScript handler to process the callback. Here's a minimal example you can try out:
 
-<pre><code class="language-html">&lt;html>
-&lt;head>
-&lt;script type="text/javascript">
-function foo(response) {
-  var meta = response.meta
-  var data = response.data
-  console.log(meta)
-  console.log(data)
-}
+    <html>
+    <head>
+    <script type="text/javascript">
+    function foo(response) {
+      var meta = response.meta;
+      var data = response.data;
+      console.log(meta);
+      console.log(data);
+    }
 
-var script = document.createElement('script');
-script.src = 'https://api.github.com?callback=foo'
+    var script = document.createElement('script');
+    script.src = 'https://api.github.com?callback=foo';
 
-document.getElementsByTagName('head')[0].appendChild(script);
-&lt;/script>
-&lt;/head>
+    document.getElementsByTagName('head')[0].appendChild(script);
+    </script>
+    </head>
 
-&lt;body>
-&lt;p>Open up your browser's console.&lt;/p>
-&lt;/body>
-
-&lt;/html></code></pre>
+    <body>
+      <p>Open up your browser's console.</p>
+    </body>
+    </html>
 
 All of the headers are the same String value as the HTTP Headers with one
 notable exception: Link.  Link headers are pre-parsed for you and come


### PR DESCRIPTION
The current parsing of the JSON-P example is broken (presumable due to the JS) and to resolve it, the code just needs to be treated as regular markdown code and not the specific code classes.

I omitted the `static/search-index.json` file from this commit as I would assume that is done on deployment but I can commit it up should it be needed.
