### PR TITLE
Add the default monospace font stack for <code> elements

### DIFF
--- a/static/shared/css/documentation.css
+++ b/static/shared/css/documentation.css
@@ -1017,7 +1017,6 @@ div.sidebar-module ul ul li span {
 .content dl code,
 .content ul code,
 p code {
-  font: 12px Monaco,"Courier New","DejaVu Sans Mono","Bitstream Vera Sans Mono",monospace;
   -webkit-border-radius: 3px;
   -moz-border-radius: 3px;
   border-radius: 3px;
@@ -1157,13 +1156,13 @@ body.api .content table td {
 
 code {
   white-space: nowrap;
-  font: 12px Monaco,"Courier New","DejaVu Sans Mono","Bitstream Vera Sans Mono",monospace;
+  font: 12px Consolas, 'Liberation Mono', Courier, monospace;
 }
 
 pre {
   border: 1px solid #cacaca;
   line-height: 1.2em;
-  font: 12px Monaco,"Courier New","DejaVu Sans Mono","Bitstream Vera Sans Mono",monospace;
+  font: 12px Consolas, 'Liberation Mono', Courier, monospace;
   padding: 10px;
   overflow:auto;
   -webkit-border-radius: 3px;


### PR DESCRIPTION
Unfortunately `<code>` elements weren't getting the monospace font stack they deserved so they looked a little out of place. :lipstick:

Turns
![github-old](https://f.cloud.github.com/assets/283234/2135391/7b549c1e-92fd-11e3-95a5-0f535c91cb08.png)
into
![github-new](https://f.cloud.github.com/assets/283234/2135392/823f2094-92fd-11e3-9429-2666166b04f0.png)
