### PR TITLE
Remove the repository from the CreateEvent

### DIFF
--- a/content/v3/activity/events/types.md
+++ b/content/v3/activity/events/types.md
@@ -34,7 +34,9 @@ Key | Type | Description
 
 ## CreateEvent
 
-Represents a created branch or tag.
+Represents a created repository, branch, or tag.
+
+Note: webhooks will not receive this event for created repositories.
 
 ### Hook name
 


### PR DESCRIPTION
There has been some confusion because, with our webhooks, there is no way to get a "CreateEvent" for a repository being created. The webhook can't be installed _before_ a repository is created. Until it is possible to receive it for a repository, we should remove it from the documentation to avoid any more confusion. :sparkles: 
