### PR TITLE
document inability to remove repo from owners team

### DIFF
--- a/content/v3/orgs/teams.md
+++ b/content/v3/orgs/teams.md
@@ -205,9 +205,10 @@ organization, you get:
 ## Remove team repository {#remove-team-repo}
 
 In order to remove a repository from a team, the authenticated user must be an
-owner of the org that the team is associated with.
+owner of the org that the team is associated with. Also, since the Owners team
+always has access to all repositories in the organization, repositories cannot
+be removed from the Owners team.
 NOTE: This does not delete the repository, it just removes it from the team.
-NOTE: Repositories cannot be removed from the owners team.
 
     DELETE /teams/:id/repos/:owner/:repo
 


### PR DESCRIPTION
It's impossible to remove a repository from the owners team. You just can't do it.

You also shouldn't have two notes. Let's tighten this up.
