### PR TITLE
add updated_at to MILESTONE resource

### DIFF
--- a/lib/resources.rb
+++ b/lib/resources.rb
@@ -388,6 +388,7 @@ module GitHub
       "open_issues"   => 4,
       "closed_issues" => 8,
       "created_at"    => "2011-04-10T20:09:31Z",
+      "updated_at"  => "2014-03-03T18:58:10Z",
       "due_on"        => nil
     }
 


### PR DESCRIPTION
This field `updated_at` is available in the API, so this adds it to the documentation too.
