### PR TITLE
Fix link to event types

### DIFF
--- a/content/v3/repos/hooks.md
+++ b/content/v3/repos/hooks.md
@@ -141,7 +141,7 @@ GitHub will send along a few HTTP headers to differentiate between event types a
 
 Name | Description
 -----|-----------|
-`X-GitHub-Event` | The [event type](#events) that was triggered.
+`X-GitHub-Event` | The [event type](/v3/activity/events/types/) that was triggered.
 `X-GitHub-Delivery` | A [guid][guid] to identify the payload and event being sent.
 `X-GitHub-Signature` | The value of this header is computed as the HMAC hex digest of the body, using the `secret` config option as the key.
 


### PR DESCRIPTION
Link to the event types page from the `X-GitHub-Event` documentation. Fixes [this build failure](https://travis-ci.org/github/developer.github.com/builds/20634990#L64).

/cc @atmos
