### PR TITLE
Add explanation for score field for search results

### DIFF
--- a/content/v3/search.md
+++ b/content/v3/search.md
@@ -18,6 +18,8 @@ search results so that you can find the item that best meets your needs. To
 satisfy that need, the GitHub Search API provides **up to 1,000 results for each
 search**.
 
+### Ranking search results
+
 Unless another sort option is provided as a query parameter, results are sorted
 by best match, as indicated by the `score` field for each item returned. This
 is a computed value representing the relevance of a item relative to the other


### PR DESCRIPTION
Adds a blurb to the search docs to explain the `score` field for search results.

@grantr @TwP @izuzak @jasonrudolph @taddeimania
