### PR TITLE
Update gist files hash to consistently key by filename

### DIFF
--- a/lib/resources.rb
+++ b/lib/resources.rb
@@ -1226,11 +1226,12 @@ module GitHub
     }
 
     GIST_FILE = {
-      "size"     => 932,
-      "filename" => "ring.erl",
-      "raw_url"  => "https://gist.githubusercontent.com/raw/365370/8c4d2d43d178df44f4c03a7f2ac0ff512853564e/ring.erl",
-      "type"     => "text/plain",
-      "language" => "Erlang"
+      "ring.erl" => {
+        "size"     => 932,
+        "raw_url"  => "https://gist.githubusercontent.com/raw/365370/8c4d2d43d178df44f4c03a7f2ac0ff512853564e/ring.erl",
+        "type"     => "text/plain",
+        "language" => "Erlang"
+      }
     }
 
     GIST = {
@@ -1241,7 +1242,7 @@ module GitHub
       "description"  => "description of gist",
       "public"       => true,
       "user"         => USER,
-      "files"        => { "ring.erl" => GIST_FILE },
+      "files"        => GIST_FILE,
       "comments"     => 0,
       "comments_url" => "https://api.github.com/gists/#{SecureRandom.hex(10)}/comments/",
       "html_url"     => "https://gist.github.com/1",
@@ -1252,7 +1253,7 @@ module GitHub
     }
 
     FULL_GIST = GIST.merge(GIST_FORKS).merge(GIST_HISTORY)
-    FULL_GIST["files"] = GIST_FILE.merge({'content' => 'contents of gist'})
+    FULL_GIST["files"] = {"ring.erl" => GIST_FILE["ring.erl"].merge({"content" => "contents of gist"})}
 
     GIST_COMMENT = {
       "id"         => 1,


### PR DESCRIPTION
The responses returned by the API for Gists always includes a hash for files that contains a hash for each file in the gist keyed by the file's name, but this was only reflected in the example response for listing gists. This pull request updates the example responses for getting a single gist, creating a gist, and editing a gist to correct the files hash.
