### PR TITLE
Add space between required and 2fa-type

### DIFF
--- a/content/v3/auth.md
+++ b/content/v3/auth.md
@@ -56,7 +56,7 @@ want to take advantage of OAuth access token security features.
 
 For users with two-factor authentication enabled, Basic Authentication requires
 an extra step. When you attempt to authenticate with Basic Authentication, the
-server will respond with a `401` and an `X-GitHub-OTP: required;:2fa-type`
+server will respond with a `401` and an `X-GitHub-OTP: required; :2fa-type`
 header. This indicates that a two-factor authentication code is needed (in
 addition to the username and password). The `:2fa-type` in this header indicates
 whether the account receives its two-factor authentication codes via SMS or via


### PR DESCRIPTION
It's causing confusion for client implementation. See https://github.com/github/hub/pull/515#discussion_r10908721 for details.

Client implementations:
- https://github.com/octokit/go-octokit/blob/24c866c6d831ace4b2753f2e939ab1aaeb265a55/octokit/error.go#L120
- https://github.com/octokit/octokit.rb/blob/ab0404e0f1c6d36ed52c6e9c8c9734a5f14ec839/lib/octokit/error.rb#L155
