### PR TITLE
changed link to push event

### DIFF
--- a/content/webhooks/index.md
+++ b/content/webhooks/index.md
@@ -84,7 +84,7 @@ Name | Description
 
 The payloads for all hooks mirror [the payloads for the Event
 types](/v3/activity/events/types/), with the exception of [the original `push`
-event](http://help.github.com/post-receive-hooks/),
+event](http://developer.github.com/v3/activity/events/types/#pushevent),
 which has a more detailed payload.
 
 ## Wildcard Event


### PR DESCRIPTION
the link to the push event currently redirects to the initial page on [webhooks](https://help.github.com/articles/creating-webhooks), which just directs users to this page

this fixes the circular linking, by instead linking to the push event reference
