### PR TITLE
Remove &trade;

### DIFF
--- a/content/v3/pulls.md
+++ b/content/v3/pulls.md
@@ -175,7 +175,7 @@ Note: The response includes a maximum of 250 commits. If you are working with a 
 
 <%= headers 404 %>
 
-## Merge a pull request (Merge Button&trade;)
+## Merge a pull request (Merge Button)
 
     PUT /repos/:owner/:repo/pulls/:number/merge
 


### PR DESCRIPTION
This has been a lighthearted joke at GitHub for a while, but people take it seriously, and claiming to have a trademark actually does have implications. This removes the `&trade;` from the pull request docs.
