### PR TITLE
Corrected OAuth scopes required.

### DIFF
--- a/content/v3/orgs/teams.md
+++ b/content/v3/orgs/teams.md
@@ -9,7 +9,7 @@ title: Organization Teams | GitHub API
 
 All actions against teams require at a minimum an authenticated user who
 is a member of the Owners team in the `:org` being managed. Additionally,
-OAuth users require the "read:org" [scopes](/v3/oauth/#scopes).
+OAuth users require the "read:org" [scope](/v3/oauth/#scopes).
 
 ## List teams
 


### PR DESCRIPTION
I thought requiring a "user" OAuth scope for reading team membership was a bit odd, so I tried it with "read:org" and it worked, so correcting the documentation. "write:org" and "admin:org" are untested, but would make more sense than "user".
