### PR TITLE
Clarified that the rate limit is per user

### DIFF
--- a/v3/index.html
+++ b/v3/index.html
@@ -480,6 +480,8 @@ requests per hour. For unauthenticated requests, the rate limit allows you to
 make up to 60 requests per hour. (The Search API has <a href="/v3/search/#rate-limit">custom rate limit
 rules</a>.)</p>
 
+<p>Each user of your application gets their own rate limit, so if you have two users and one user uses up all 5,000 requests, the other user will still have 5,000 requests.</p>
+
 <p>You can check the returned HTTP headers of any API request to see your current
 rate limit status:</p>
 


### PR DESCRIPTION
The documentation wasn't very clear about whether all users of an application shared a common rate limit, or if each user gets there own rate limit, so I had to contact GitHub for clarification.

To help future developers who are confused about this, I've added a sentence explaining that each user of an app gets his own rate limit.
