### PR TITLE
Fix docs for name of GitHub signature request header

### DIFF
--- a/content/v3/repos/hooks.md
+++ b/content/v3/repos/hooks.md
@@ -143,7 +143,7 @@ Name | Description
 -----|-----------|
 `X-GitHub-Event` | The [event type](/v3/activity/events/types/) that was triggered.
 `X-GitHub-Delivery` | A [guid][guid] to identify the payload and event being sent.
-`X-GitHub-Signature` | The value of this header is computed as the HMAC hex digest of the body, using the `secret` config option as the key.
+`X-Hub-Signature` | The value of this header is computed as the HMAC hex digest of the body, using the `secret` config option as the key.
 
 ## PubSubHubbub
 


### PR DESCRIPTION
The documentation correctly refers to it as `X-Hub-Signature` in every place but one, where it uses `X-GitHub-Signature`. This PR corrects this use.

I've verified that `X-Hub-Signature` is the correct value, and that there is no `X-GitHub-Signature` header sent, in my own personal use, and by reviewing GitHub's [webhook code](https://github.com/github/github-services/blob/f3bb3dd780feb6318c42b2db064ed6d481b70a1f/lib/service/http_helper.rb#L76).

The inconsistency in request header naming is probably something to fix, but that's someone else's problem. :smile: 
