### PR TITLE
Add ability to skip adding a commit message when publishing

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -24,11 +24,13 @@ def commit_message
     ':sailboat:', ':gift:', ':ship:', ':shipit:', ':sparkles:', ':rainbow:']
   default_message = "P U B L I S H #{publish_emojis.sample}"
 
-  print "Enter a commit message (default: '#{default_message}'): "
-  STDOUT.flush
-  mesg = STDIN.gets.chomp.strip
+  unless ENV["no_commit_msg"]
+    print "Enter a commit message (default: '#{default_message}'): "
+    STDOUT.flush
+    mesg = STDIN.gets.chomp.strip
+  end
 
-  mesg = default_message if mesg == ''
+  mesg = default_message if mesg.nil? || mesg == ''
   mesg.gsub(/'/, '') # Allow this to be handed off via -m '#{message}'
 end
 


### PR DESCRIPTION
The idea is that you can just run `rake publish no_commit_msg=true` to skip the required input for a commit message. This is useful for, say, automated system to publish the docs automagically.

Unfortunately you can't use hyphens with rake arguments so there aren't a lot of pretty ways to do this.
