### PR TITLE
Update OAuth scope docs for creating a repository

### DIFF
--- a/content/v3/repos.md
+++ b/content/v3/repos.md
@@ -83,9 +83,7 @@ Name | Type | Description
 
 ## Create
 
-Create a new repository for the authenticated user. (OAuth users must supply
-`public_repo` scope or `repo` scope to create a public repository. OAuth users
-must supply `repo` scope to create a private repository.)
+Create a new repository for the authenticated user.
 
     POST /user/repos
 
@@ -93,6 +91,13 @@ Create a new repository in this organization. The authenticated user must
 be a member of the specified organization.
 
     POST /orgs/:org/repos
+
+### OAuth scope requirements
+
+When using [OAuth](/v3/oauth/#scopes), authorizations must include:
+
+- `public_repo` scope or `repo` scope to create a public repository
+- `repo` scope to create a private repository
 
 ### Input
 


### PR DESCRIPTION
We recently added support for creating a public repository with `public_repo` scope (instead of requiring `repo`) scope. We [announced it via the blog](http://git.io/l3FRng), but the inline docs for the [Create Repository method](https://developer.github.com/v3/repos/#create) still state that `repo` scope is required. This pull request updates the docs to reflect reality.

Thanks to @mczepiel for [identifying](https://twitter.com/mczepiel/status/459381611209846784) this shortcoming in the docs.
