### PR TITLE
Update wording around "Payload version" in favor of "Content type" in Webhooks docs

### DIFF
--- a/content/webhooks/creating/index.md
+++ b/content/webhooks/creating/index.md
@@ -39,11 +39,14 @@ We'll explain why in the [Configuring Your Server](/webhooks/configuring/) docs.
 
 ## Content Type
 
-Webhooks can be delivered using different content types. The `application/json` content
-type will deliver the JSON payload directly as the body of the POST. The
-`application/x-www-form-urlencoded` content type will send the JSON payload as a form
-parameter called "payload".  Choose the one that best fits your needs. For this tutorial,
-the default content type is fine.
+Webhooks can be delivered using different content types:
+
+- The `application/json` content type will deliver the JSON payload directly as the body of the POST.
+- The `application/x-www-form-urlencoded` content type will send the JSON payload as a form parameter
+  called "payload".
+
+Choose the one that best fits your needs. For this tutorial, the default content type of
+`application/json` is fine.
 
 ## Events
 


### PR DESCRIPTION
We recently renamed the "Payload version" field in the webhooks form to "Content type". We don't support full-fledged versioned media types yet so it only adds confusion.

/cc @atmos @kdaigle @gjtorikian 
