### PR TITLE
Fix paragraph styling

### DIFF
--- a/content/webhooks/index.md
+++ b/content/webhooks/index.md
@@ -22,7 +22,7 @@ can configure hooks programmatically [via the API](/v3/repos/hooks/).
 A service is basically the name used to refer to a hook that has configuration
 settings, a list of available events, and default events.
 
-> For instance, the
+For instance, the
 [email](https://github.com/github/github-services/blob/master/lib/services/email.rb)
 service is a built-in GitHub service that will send event [payloads](#payloads)
 to, at most, two email addresses.  It will trigger for the `push`


### PR DESCRIPTION
Pretty sure this is a mistake.

Before:

![screen shot 2014-05-12 at 09 05 30](https://cloud.githubusercontent.com/assets/211284/2941465/300797be-d9a4-11e3-9b4d-eac10771cca1.png)

After:

![screen shot 2014-05-12 at 09 07 14](https://cloud.githubusercontent.com/assets/211284/2941468/3316f756-d9a4-11e3-9c1a-d6ac3e2d65f1.png)
