### PR TITLE
Deprecate plan["collaborators"] attribute

### DIFF
--- a/content/v3/versions.md
+++ b/content/v3/versions.md
@@ -91,6 +91,9 @@ The recommendations below will help you prepare your application for the next ma
 1. User attribute: bio
 : Recommendation: Do not use this attribute. It is obsolete.
 
+1. User attribute: plan["collaborators"]
+: Recommendation: Do not use this attribute. It is obsolete.
+
 1. Pagination parameters `top` and `sha` for method: /repos/:owner/:repo/commits
 : Recommendation: When fetching [the list of commits for a repository](/v3/repos/commits/#list-commits-on-a-repository)
   use the [standard `per_page` and `page` parameters](/v3/#pagination) for pagination, instead of `per_page`,

--- a/lib/resources.rb
+++ b/lib/resources.rb
@@ -161,8 +161,11 @@ module GitHub
       "plan"                => {
         "name"          => "Medium",
         "space"         => 400,
-        "collaborators" => 10,
-        "private_repos" => 20
+        "private_repos" => 20,
+        "collaborators" => 0 # Plans now allow *unlimited* collaborators, so
+                             # this attribute is deprecated. However, the beta
+                             # and v3 media types need to continue to return an
+                             # integer value for backwards compatibility.
       }
     })
 


### PR DESCRIPTION
Personal plans and organization plans used to allow a finite number of collaborators. The API used to return the allowed number of collaborators for each plan in the `collaborators` attribute:

```
{
  "login": "jasonrudolph",
  ...
  "plan": {
    "name": "medium",
    "space": 2516582,
    "collaborators": 10,
    "private_repos": 20
  }
}
```

Now, these [plans allow unlimited collaborators](https://github.com/pricing). As a result, this attribute is no longer meaningful. We will remove it in the next major version of the API. In the meantime, for backwards compatibility purposes, the v3 API and the beta API continue to provide an integer value (`0`) for the attribute.

```
{
  "login": "jasonrudolph",
  ...
  "plan": {
    "name": "medium",
    "space": 2516582,
    "collaborators": 0,
    "private_repos": 20
  }
}
```

This PR adds this attribute to the [list of v3 deprecations](https://developer.github.com/v3/versions/#v3-deprecations), and it updates the example response to match current functionality.
