### PR TITLE
Set program octicons to black

### DIFF
--- a/static/css/documentation.css
+++ b/static/css/documentation.css
@@ -1255,7 +1255,7 @@ pre span.comment {color: #aaa;}
   position: absolute;
   left: 0;
   top: 32px;
-  color: #000;
+  color: #333;
 }
 
 .program-info-column ul {


### PR DESCRIPTION
Turns

![screen shot 2014-05-15 at 10 38 38 am](https://cloud.githubusercontent.com/assets/64050/2988259/cb2c536e-dc57-11e3-9696-8416a4f5821b.png)

into

![screen shot 2014-05-15 at 10 38 45 am](https://cloud.githubusercontent.com/assets/64050/2988258/cb2b8ec0-dc57-11e3-80b9-51ee5e5dbe6b.png)

I don't like the blue because it's the same color as anchors throughout the site, and the visual cue is false--these are not links. 

/cc @fabianperez @tobiasahlin 
