### PR TITLE
Clarify FollowEvent creation and usage

### DIFF
--- a/content/v3/activity/events/types.md
+++ b/content/v3/activity/events/types.md
@@ -128,7 +128,7 @@ Key | Type | Description
 
 Triggered when a user [follows another user](/v3/users/followers/#follow-a-user).
 
-Events of this type are **no longer created in timelines**, but it's possible that they exist in timelines of some users.
+Events of this type are **no longer created**, but it's possible that they exist in timelines of some users.
 
 ### Hook name
 


### PR DESCRIPTION
Change "not visible in timelines" to "no longer created in timelines"

Currently the docs state that the FollowEvent is not visible in timelines, this is incorrect as I have one in my timeline [Example](https://github.com/thebinarypenguin/guaw/wiki/User-Activity#followevent). However since it's from 2012 I assume the docs should state the the FollowEvent is **no longer** created in timelines.
