### PR TITLE
Remove "repository" from create webhook event description

### DIFF
--- a/content/webhooks/index.md
+++ b/content/webhooks/index.md
@@ -69,7 +69,7 @@ Name | Description
 -----|-----------|
 `*` | Any time any event is triggered ([Wildcard Event](#wildcard-event)).
 `commit_comment` | Any time a Commit is commented on.
-`create` | Any time a Repository, Branch, or Tag is created.
+`create` | Any time a Branch or Tag is created.
 `delete` | Any time a Branch or Tag is deleted.
 `deployment` | Any time a Repository has a new deployment created from the API.
 `deployment_status` | Any time a deployment for the Repository has a status update from the API.


### PR DESCRIPTION
Brings `create` in line with `delete`. It seems notification of a repository being created doesn't make sense since you have to set up the webhook on an already created repository. I asked support and Jamie Murai wrote back to say

> Thanks for letting us know about this. That's a mistake in the documentation. At this time, you cannot get "create" events when a repo is created. This is because a webhook must be added to a repository, so the repository must already exist.
