### PR TITLE
PHP library Kdyby/Github for Nette Framework

### DIFF
--- a/content/libraries.md
+++ b/content/libraries.md
@@ -111,12 +111,14 @@ covers the entire API.
 * [GitHub API][github-api]
 * [GitHub Kohana Module][kohana]
 * [GitHub Joomla! Package][joomla]
+* [Github Nette Extension][kdyby-github]
 
 [github-php-client]: https://github.com/tan-tan-kanarek/github-php-client
 [php-github-api]: https://github.com/KnpLabs/php-github-api
 [github-api]: https://github.com/yiiext/github-api
 [kohana]: https://github.com/acoulton/github_v3_api
 [joomla]: https://github.com/joomla/joomla-framework
+[kdyby-github]: https://github.com/kdyby/github
 
 ## Python
 


### PR DESCRIPTION
The library [Kdyby/Github](https://github.com/kdyby/github) provides Github authentication and Github api v3 communication for [Nette Framework](http://nette.org/en/). Nette is the most popular PHP framework in the Czech Republic.

It can be installed using Composer as [kdyby/github](https://packagist.org/packages/kdyby/github) package.
If you wanna, you can test the authentication at [help.kdyby.org](https://help.kdyby.org/) :bowtie:

Because the library uses only subset of Nette (Nette is [composed of components](https://github.com/nette/) similarly to [Symfony](https://github.com/symfony)), it can be used also in projects that don't wanna use whole Nette Framework.
