### PR TITLE
Explain :user means username, not ID.

### DIFF
--- a/content/v3/users.md
+++ b/content/v3/users.md
@@ -13,6 +13,9 @@ does not include a `:user` parameter then the response will be for the
 logged in user (and you must pass [authentication
 information](/v3/#authentication) with your request).
 
+Throughout this documentation, the `:user` parameter denotes the username,
+not the user ID.
+
 ## Get a single user
 
     GET /users/:user


### PR DESCRIPTION
It's the first question that comes to mind when you see `:user`, and that's the first place I searched for an answer.
