### PR TITLE
Link to milo/github-api PHP library

### DIFF
--- a/content/libraries.md
+++ b/content/libraries.md
@@ -112,6 +112,7 @@ covers the entire API.
 * [GitHub Kohana Module][kohana]
 * [GitHub Joomla! Package][joomla]
 * [Github Nette Extension][kdyby-github]
+* [GitHub API Easy Access][milo-github-api]
 
 [github-php-client]: https://github.com/tan-tan-kanarek/github-php-client
 [php-github-api]: https://github.com/KnpLabs/php-github-api
@@ -119,6 +120,7 @@ covers the entire API.
 [kohana]: https://github.com/acoulton/github_v3_api
 [joomla]: https://github.com/joomla/joomla-framework
 [kdyby-github]: https://github.com/kdyby/github
+[milo-github-api]: https://github.com/milo/github-api
 
 ## Python
 


### PR DESCRIPTION
Since I was unable to find a small but still widely usable, documented and tested library I created [milo/github-api](https://github.com/milo/github-api). After few months of using it I would like to share it.

It is library wihout dependencies, it cares about HTTP requests caching and performance. It doesn't contain hundreds of classes but only few essentials which serves Github API data in a raw form. It is something I was missing and I believe I wasn't alone.

Best regards, Milo
