### PR TITLE
Webhook json is sent in the body of the POST, not as a form parameter

### DIFF
--- a/content/webhooks/configuring/index.md
+++ b/content/webhooks/configuring/index.md
@@ -52,7 +52,7 @@ setup might look something like this:
     require 'json'
 
     post '/payload' do
-      push = JSON.parse(params[:payload])
+      push = JSON.parse(request.body.read)
       puts "I got some JSON: #{push.inspect}"
     end
 


### PR DESCRIPTION
The current example is not working: params is empty.
see: [https://developer.github.com/webhooks/creating/#content-type](https://developer.github.com/webhooks/creating/#content-type)

> “The application/json content type will deliver the JSON payload directly as the body of the POST”

And 

>  "For this tutorial, the default content type of application/json is fine"
