### PR TITLE
JSON has objects, not hashes

### DIFF
--- a/content/v3.md
+++ b/content/v3.md
@@ -121,7 +121,7 @@ receive request bodies:
         HTTP/1.1 400 Bad Request
         Content-Length: 40
 
-        {"message":"Body should be a JSON Hash"}
+        {"message":"Body should be a JSON object"}
 
 3. Sending invalid fields will result in a `422 Unprocessable Entity`
    response.

--- a/content/v3/gists.md
+++ b/content/v3/gists.md
@@ -62,11 +62,11 @@ Name | Type | Description
 
 Name | Type | Description
 -----|------|--------------
-`files`|`hash` | **Required**. Files that make up this gist.
+`files`|`object` | **Required**. Files that make up this gist.
 `description`|`string` | A description of the gist.
 `public`|`boolean` | Indicates whether the gist is public. Default: `false`
 
-The keys in the `files` hash are the `string` filename, and the value is another `hash` with a key of `content`, and a value of the file contents. For example:
+The keys in the `files` object are the `string` filename, and the value is another `object` with a key of `content`, and a value of the file contents. For example:
 
 <%= json \
   :description => "the description for this gist",
@@ -96,11 +96,11 @@ The keys in the `files` hash are the `string` filename, and the value is another
 Name | Type | Description
 -----|------|--------------
 `description`|`string` | A description of the gist.
-`files`|`hash` | Files that make up this gist.
+`files`|`object` | Files that make up this gist.
 `content`|`string` | Updated file contents.
 `filename`|`string` | New name for this file.
 
-The keys in the `files` hash are the `string` filename. The value is another `hash` with a key of `content` (indicating the new contents), or `filename` (indicating the new filename). For example:
+The keys in the `files` object are the `string` filename. The value is another `object` with a key of `content` (indicating the new contents), or `filename` (indicating the new filename). For example:
 
 <%= json \
   :description => "the description for this gist",
@@ -113,7 +113,7 @@ The keys in the `files` hash are the `string` filename. The value is another `ha
 
 <div class="alert">
   <p>
-    <strong>Note</strong>: All files from the previous version of the gist are carried over by default if not included in the hash. Deletes can be performed by including the filename with a `null` hash.
+    <strong>Note</strong>: All files from the previous version of the gist are carried over by default if not included in the object. Deletes can be performed by including the filename with a `null` value.
 	</p>
 </div>
 

--- a/content/v3/rate_limit.md
+++ b/content/v3/rate_limit.md
@@ -36,16 +36,16 @@ Note: Accessing this endpoint does not count against your rate limit.
 The Search API has a [custom rate limit](/v3/search/#rate-limit), separate from
 the rate limit governing the rest of the API. For that reason, the response
 (shown above) categorizes your rate limit by resource. Within the `"resources"`
-hash, the `"search"` hash provides your rate limit status for the
-[Search API](/v3/search). The `"core"` hash provides your rate limit status for
+object, the `"search"` object provides your rate limit status for the
+[Search API](/v3/search). The `"core"` object provides your rate limit status for
 all the _rest_ of the API.
 
 #### Deprecation Notice
 
-The `"rate"` hash (shown at the bottom of the response above) is
+The `"rate"` object (shown at the bottom of the response above) is
 [deprecated](/v3/versions/#v3-deprecations) and is scheduled for removal in the next
 version of the API.
 
 If you're writing new API client code (or updating your existing code), you
-should use the `"core"` hash instead of the `"rate"` hash. The `"core"` hash
-contains the same information that is present in the `"rate"` hash.
+should use the `"core"` object instead of the `"rate"` object. The `"core"` object
+contains the same information that is present in the `"rate"` object.


### PR DESCRIPTION
It’s confusing for the docs to refer to “hashes” when the API’s representation format is JSON, and in JSON parlance that data structure is called an “object” not a “hash”. Since users of the API may be using various languages that may or may not have a data structure called a “hash” it’s better to use the platform-agnostic parlance of JSON.
