### PR TITLE
Add GitHub.dart to Libraries (First Dart Library)

### DIFF
--- a/content/libraries.md
+++ b/content/libraries.md
@@ -17,6 +17,12 @@ many flavors</h1>
 
 # Third-party libraries
 
+## Dart
+
+* [github.dart][github.dart]
+
+[github.dart]: https://github.com/DirectMyFile/github.dart
+
 ## .NET
 
 * [IronGithub][irongithub]


### PR DESCRIPTION
This adds my GitHub.dart library to the libraries list. This is the only GitHub library in existence for Dart.
