### PR TITLE
Remove errant note about redirect in /orgs/:org/members

### DIFF
--- a/content/v3/orgs/members.md
+++ b/content/v3/orgs/members.md
@@ -12,8 +12,7 @@ title: Organization Members | GitHub API
 List all users who are members of an organization. A member is a user that
 belongs to at least 1 team in the organization. If the authenticated user is
 also an owner of this organization then both concealed and public members will
-be returned. If the requester is not an owner of the organization the query
-will be redirected to the [public members list](#public-members-list).
+be returned.
 
     GET /orgs/:org/members
 


### PR DESCRIPTION
This was only true for a few hours two years ago.

---

@gjtorikian @izuzak 
