### PR TITLE
Replace 'commiter' with 'committer'

### DIFF
--- a/content/v3/git/commits.md
+++ b/content/v3/git/commits.md
@@ -31,7 +31,7 @@ Name | Type | Description
 
 ### Optional Parameters
 
-You can provide an additional `commiter` parameter, which is a hash containing
+You can provide an additional `committer` parameter, which is a hash containing
 information about the committer. Or, you can provide an `author` parameter, which
 is a hash containing information about the author.
 
@@ -39,12 +39,12 @@ The `committer` section is optional and will be filled with the `author`
 data if omitted. If the `author` section is omitted, it will be filled
 in with the authenticated user's information and the current date.
 
-Both the `author` and `commiter` parameters have the same keys:
+Both the `author` and `committer` parameters have the same keys:
 
 Name | Type | Description
 -----|------|-------------
-`name`|`string` | The name of the author (or commiter) of the commit
-`email`|`string` | The email of the author (or commiter) of the commit
+`name`|`string` | The name of the author (or committer) of the commit
+`email`|`string` | The email of the author (or committer) of the commit
 `date`|`string` | Indicates when this commit was authored (or committed). This is a timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`.
 
 ### Example Input

--- a/content/v3/repos/contents.md
+++ b/content/v3/repos/contents.md
@@ -101,7 +101,7 @@ Name | Type | Description
 
 ### Optional Parameters
 
-You can provide an additional `commiter` parameter, which is a hash containing
+You can provide an additional `committer` parameter, which is a hash containing
 information about the committer. Or, you can provide an `author` parameter, which
 is a hash containing information about the author.
 
@@ -112,12 +112,12 @@ user's information is used.
 You must provide values for both `name` and `email`, whether you choose to use
 `author` or `committer`. Otherwise, you'll receive a `422` status code.
 
-Both the `author` and `commiter` parameters have the same keys:
+Both the `author` and `committer` parameters have the same keys:
 
 Name | Type | Description
 -----|------|--------------
-`name`|`string` | The name of the author (or commiter) of the commit
-`email`|`string` | The email of the author (or commiter) of the commit
+`name`|`string` | The name of the author (or committer) of the commit
+`email`|`string` | The email of the author (or committer) of the commit
 
 ### Example Input
 
@@ -149,7 +149,7 @@ Name | Type | Description
 
 ### Optional Parameters
 
-You can provide an additional `commiter` parameter, which is a hash containing
+You can provide an additional `committer` parameter, which is a hash containing
 information about the committer. Or, you can provide an `author` parameter, which
 is a hash containing information about the author.
 
@@ -160,12 +160,12 @@ user's information is used.
 You must provide values for both `name` and `email`, whether you choose to use
 `author` or `committer`. Otherwise, you'll receive a `422` status code.
 
-Both the `author` and `commiter` parameters have the same keys:
+Both the `author` and `committer` parameters have the same keys:
 
 Name | Type | Description
 -----|------|--------------
-`name`|`string` | The name of the author (or commiter) of the commit
-`email`|`string` | The email of the author (or commiter) of the commit
+`name`|`string` | The name of the author (or committer) of the commit
+`email`|`string` | The email of the author (or committer) of the commit
 
 ### Example Input
 
@@ -198,7 +198,7 @@ Name | Type | Description
 
 ### Optional Parameters
 
-You can provide an additional `commiter` parameter, which is a hash containing
+You can provide an additional `committer` parameter, which is a hash containing
 information about the committer. Or, you can provide an `author` parameter, which
 is a hash containing information about the author.
 
@@ -209,12 +209,12 @@ user's information is used.
 You must provide values for both `name` and `email`, whether you choose to use
 `author` or `committer`. Otherwise, you'll receive a `422` status code.
 
-Both the `author` and `commiter` parameters have the same keys:
+Both the `author` and `committer` parameters have the same keys:
 
 Name | Type | Description
 -----|------|--------------
-`name`|`string` | The name of the author (or commiter) of the commit
-`email`|`string` | The email of the author (or commiter) of the commit
+`name`|`string` | The name of the author (or committer) of the commit
+`email`|`string` | The email of the author (or committer) of the commit
 
 ### Example Input
 


### PR DESCRIPTION
I noticed one example while looking at the [docs](https://developer.github.com/v3/git/commits/#optional-parameters) but there are a few more. I'm assuming they can all be changed.
