### PR TITLE
Fixed API limit message

### DIFF
--- a/content/v3.md
+++ b/content/v3.md
@@ -377,7 +377,8 @@ X-RateLimit-Remaining: 0
 X-RateLimit-Reset: 1377013266
 
 {
-    "message": "API rate limit exceeded. See https://developer.github.com/v3/#rate-limiting for details."
+    "message": "API rate limit exceeded for xxx.xxx.xxx.xxx. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)",
+    "documentation_url": "https://developer.github.com/v3/#rate-limiting"
 }
 </pre>
 


### PR DESCRIPTION
I looks like you've changed the API limit message on your active API, but forgot to change it's demonstration on the documentation. Here is the change.
