### PR TITLE
Update v3.md

### DIFF
--- a/content/v3.md
+++ b/content/v3.md
@@ -46,7 +46,7 @@ X-Content-Type-Options: nosniff
 
 Blank fields are included as `null` instead of being omitted.
 
-All timestamps are returned in ISO 8601 format:
+All timestamps are returned in [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format (a strict subset of ISO 8601):
 
     YYYY-MM-DDTHH:MM:SSZ
 


### PR DESCRIPTION
It seems to be better to mention RFC 3339 instead of ISO 8601. RFC 3339 is far simpler, clear and easier to use unlike complex and vague ISO 8601. Then it can decrease a lot of validation concerns of API users. Anyway this is based on my guess, so maybe wrong.

Though I am not a Github employee, I am sending this PR because the public site is saying it's encouraged.