### PR TITLE
Fix confusing about missing "plan" field of user data due to missing "user" scope

### DIFF
--- a/content/guides/getting-started.md
+++ b/content/guides/getting-started.md
@@ -196,8 +196,8 @@ Also, the [**Authorizations API**][authorizations api] makes it simple to use Ba
 to create an OAuth token. Try pasting and running the following command:
 
 <pre class="terminal">
-$ curl -i -u &lt;your_username&gt; -d '{"scopes": ["repo"], "note": "getting-started"}' \
-    https://api.github.com/authorizations
+$ curl -i -u &lt;your_username&gt; -d '{"scopes": ["repo", "public_repo", "user", "gist"], \
+"note": "getting-started"}' https://api.github.com/authorizations
 
 HTTP/1.1 201 Created
 Location: https://api.github.com/authorizations/2
@@ -205,7 +205,10 @@ Content-Length: 384
 
 {
   "scopes": [
-    "repo"
+    "repo",
+    "public_repo",
+    "user",
+    "gist"
   ],
   "token": "5199831f4dd3b79e7c5b7e0ebe75d67aa66e79d4",
   "updated_at": "2012-11-14T14:04:24Z",
@@ -230,7 +233,9 @@ Next, let's look at the `scopes` we're sending over in this call. When creating
 a new token, we include an optional array of [_scopes_][scopes], or access
 levels, that indicate what information this token can access. In this case,
 we're setting up the token with _repo_ access, which grants access to read and
-write to private repositories. See [the scopes docs][scopes] for a full list of
+write to private repositories, _public\_repo_ grants access to read and write to
+ public repositories, _user_ grants access to read and write to all user data, and
+  _gist_ grants access to create new gists. See [the scopes docs][scopes] for a full list of
 scopes. You should **only** request scopes that your application actually needs,
 in order to not frighten users with potentially invasive actions. The `201`
 status code tells us that the call was successful, and the JSON returned
@@ -243,8 +248,8 @@ in the [X-GitHub-OTP request header][2fa header]:
 
 <pre class="terminal">
 $ curl -i -u &lt;your_username&gt; -H "X-GitHub-OTP: &lt;your_2fa_OTP_code&gt;" \
-    -d '{"scopes": ["repo"], "note": "getting-started"}' \
-    https://api.github.com/authorizations
+    -d '{"scopes": ["repo", "public_repo", "user", "gist"], \
+    "note": "getting-started"}' https://api.github.com/authorizations
 </pre>
 
 If you enabled 2FA with a mobile application, go ahead and get an OTP code from


### PR DESCRIPTION
Readers may confuse when they create OAuth token following the example
curl command instead on the web form and noticed that the "plan" user
data field not displayed even when they're authenticated successfully
due to the missing "user" scope access.

This commit fixes this issue by also request "repo", "public_repo",
"user", and "gist" scope in the Oauth token command-line request cases
thus the result will be same with the one using GitHub's webform.

NOTE that this change may needs further lingual and cosmetic patches to make it
well-looking enough.

Signed-off-by: Ｖ字龍(Vdragon) <Vdragon.Taiwan@gmail.com>