### PR TITLE
Clarify differences between Events API and webhooks

### DIFF
--- a/content/v3/activity/events/types.md
+++ b/content/v3/activity/events/types.md
@@ -9,7 +9,7 @@ determined by its event type.
 
 Event names are used by [repository webhooks](/v3/repos/hooks/) to specify
 which events the webhook should receive. The included payloads below are from webhook deliveries but
-match events returned by the [Events API](/v3/activity/events/) (except where noted).
+match events returned by the [Events API](/v3/activity/events/) (except where noted). The events API uses the CamelCased name (e.g. `CommitCommentEvent`) in the `type` field of an event object.
 
 
 Note that some of these events may not be rendered in timelines.

--- a/content/v3/activity/events/types.md
+++ b/content/v3/activity/events/types.md
@@ -9,7 +9,7 @@ determined by its event type.
 
 Event names are used by [repository webhooks](/v3/repos/hooks/) to specify
 which events the webhook should receive. The included payloads below are from webhook deliveries but
-match events returned by the [Events API](/v3/activity/events/) (except where noted). The events API uses the CamelCased name (e.g. `CommitCommentEvent`) in the `type` field of an event object.
+match events returned by the [Events API](/v3/activity/events/) (except where noted). The Events API uses the CamelCased name (e.g. `CommitCommentEvent`) in the `type` field of an event object and does not include the `repository` or `sender` fields in the event payload object.
 
 
 Note that some of these events may not be rendered in timelines.


### PR DESCRIPTION
I'd assumed that the name under "Event name" was used in the `type` field of the event object but I was wrong. There is a hint that the camel-cased variant is used on the Events page in the form of `"type": "Event"` but it's best to be explicit, anyway. Anyone who uses the API will notice immediately, anyway.