### PR TITLE
Mark the labels param as required for issue creation

### DIFF
--- a/content/v3/issues.md
+++ b/content/v3/issues.md
@@ -94,7 +94,7 @@ Name | Type | Description
 `body`|`string` | The contents of the issue.
 `assignee`|`string` | Login for the user that this issue should be assigned to. _NOTE: Only users with push access can set the assignee for new issues. The assignee is silently dropped otherwise._
 `milestone`|`number` | Milestone to associate this issue with. _NOTE: Only users with push access can set the milestone for new issues. The milestone is silently dropped otherwise._
-`labels`|`array` of `strings` | Labels to associate with this issue. _NOTE: Only users with push access can set labels for new issues. Labels are silently dropped otherwise._
+`labels`|`array` of `strings` | **Required**. Labels to associate with this issue, or an empty array if no labels should be set. _NOTE: Only users with push access can set labels for new issues. Labels are silently dropped otherwise._
 
 #### Example
 


### PR DESCRIPTION
Hitting the create issue API endpoint without the `labels` param now returns a 422. This clarifies the docs by marking the `labels` as required.

See octokit/octokit.rb#538.

/cc @pengwynn
