### PR TITLE
Add octokit.js link

### DIFF
--- a/content/libraries.md
+++ b/content/libraries.md
@@ -76,6 +76,7 @@ covers the entire API.
 
 ## JavaScript
 
+* [octokit.js][https://github.com/philschatz/octokit.js]
 * [Node-GitHub][mikedeboer-node-github]
 * [NodeJS GitHub library][octonode]
 * [gh3 client-side API v3 wrapper][gh3]


### PR DESCRIPTION
octokit.js is a fork of github.js that works with v3 of the api.