### PR TITLE
Fix verbs description concerning custom actions

### DIFF
--- a/content/v3.md
+++ b/content/v3.md
@@ -191,7 +191,7 @@ Verb | Description
 -----|-----------
 `HEAD` | Can be issued against any resource to get just the HTTP header info.
 `GET` | Used for retrieving resources.
-`POST` | Used for creating resources, or performing custom actions (such as merging a pull request).
+`POST` | Used for creating resources.
 `PATCH` | Used for updating resources with partial JSON data.  For instance, an Issue resource has `title` and `body` attributes.  A PATCH request may accept one or more of the attributes to update the resource.  PATCH is a relatively new and uncommon HTTP verb, so resource endpoints also accept `POST` requests.
 `PUT` | Used for replacing resources or collections. For `PUT` requests with no `body` attribute, be sure to set the `Content-Length` header to zero.
 `DELETE` |Used for deleting resources.


### PR DESCRIPTION
From [the documentation](https://github.com/github/developer.github.com/blob/1aaa1d1ebcea67922ee2df12e1ec38d27ae87fa0/content/v3.md):
```curl
PUT /repos/:owner/:repo/pulls/:number/merge
```

Custom actions are using `PUT` instead of `POST`.