### PR TITLE
Fixed sample pull request review comment payload

### DIFF
--- a/lib/webhooks/pull_request_review_comment.payload.json
+++ b/lib/webhooks/pull_request_review_comment.payload.json
@@ -1,5 +1,4 @@
 {
-  "action": "created",
   "comment": {
     "url": "https://api.github.com/repos/baxterthehacker/public-repo/pulls/comments/18682909",
     "id": 18682909,


### PR DESCRIPTION
The sample ```pull_request_review_comment``` payload contains an ```action``` field that is actually not being delivered.