### PR TITLE
Broken Last-Modified + no 'since' = a bit clunky

### DIFF
--- a/content/v3/activity/events.md
+++ b/content/v3/activity/events.md
@@ -10,11 +10,13 @@ various activity streams on the site.
 * TOC
 {:toc}
 
-Events are optimized for polling with the "ETag" header.  If no new events have
-been triggered, you will see a "304 Not Modified" response, and your current
-rate limit will be untouched.  There is also an "X-Poll-Interval" header that
-specifies how often (in seconds) you are allowed to poll.  In times of high
-server load, the time may increase.  Please obey the header.
+Events are optimized for polling with the "ETag" header.  `Last-Modified` is
+returned on responses, but is inaccurate.  All events are always returned.
+If no new events have been triggered, you will see a "304 Not Modified"
+response, and your current rate limit will be untouched.  There is also an
+"X-Poll-Interval" header that specifies how often (in seconds) you are allowed
+to poll.  In times of high server load, the time may increase.  Please obey
+the header.
 
     $ curl -I https://api.github.com/users/tater/events
     HTTP/1.1 200 OK


### PR DESCRIPTION
*This would be better raised as an issue but you have them turned off.  The patch is not to be taken entirely seriously.  I'd use /contact but prefer issues to raised in the open.*

The `*/events` endpoints:

 * return a `Last-Modified` header, but it's inaccurate and doesn't change when `ETag` does (you'll easily find events streams containing events paradoxically `created_at` a time newer than the `Last-Modified` header)
 * do not support `since=<timestamp>`

`Last-Modified` should be made accurate, removed or should carry a warning, to minimise confusion.

Current behaviour means that a caller wanting to efficiently process only events since they last checked must store both the `ETag` (to avoid unconditional requests) and the timestamp (to manually discard events older than that) and still needs to request more events than they care about.  It might be neater for callers and lighter on GitHub's bandwidth to make `Last-Modified` accurate and amenable to conditional requests, and/or to support `since` so that callers need only grab the events since their last check.  That way, a single timestamp would be enough state.