### PR TITLE
Clarify whether comment types' IDs are disjoint

### DIFF
--- a/content/v3/pulls/comments.md
+++ b/content/v3/pulls/comments.md
@@ -11,6 +11,8 @@ Pull Request Review Comments are comments on a portion of the unified
 diff.  These are separate from Commit Comments (which are applied
 directly to a commit, outside of the Pull Request view), and Issue
 Comments (which do not reference a portion of the unified diff).
+Pull Request Review Comments will never share an `id` value with
+any other comment, regardless of type.
 
 Pull Request Review Comments use [these custom media
 types](#custom-media-types). You can read more about the use of media types in the API


### PR DESCRIPTION
GitHub (the site) merges the Pull Request Review Comment and Issue Comment types into a single date-ordered stream when rendering an issue.  API users may also want to do this when rendering or caching JSON, and it helps to know whether it's safe to merge based on the value of `id`.  If `id` values are disjoint across all comment types, it can be used to merge safe in the knowledge that a match means it's the same comment; if that *can't* be guaranteed/committed to (i.e. users need to do their own namespacing of comments based on type) that's useful to know too.

I've only seen disjointed IDs so that's what I've described.  A proper patch for this would mention disjointedness guarantee (or lack of) on the Issue Comments and the Commit Comments pages too.