### PR TITLE
Explicitly say event order is newest-first

### DIFF
--- a/content/v3/activity/events.md
+++ b/content/v3/activity/events.md
@@ -31,6 +31,8 @@ Events support [pagination](/v3/#pagination),
 however the `per_page` option is unsupported. The fixed page size is 30 items.
 Fetching up to ten pages is supported, for a total of 300 events.
 
+Events are always returned in newest-first order.
+
 Only events created within the past 90 days will be included in timelines. Events
 older than 90 days will not be included (even if the total number of events
 in the timeline is less than 300).


### PR DESCRIPTION
That's what I've observed, and it helps to know you can avoid a defensive sort.