### PR TITLE
Fixed ordering of Activity API overview headers

### DIFF
--- a/content/v3/activity.md
+++ b/content/v3/activity.md
@@ -6,6 +6,15 @@ title: Activity | GitHub API
 Serving up the 'social' in Social Coding, the Activity APIs provide access to
 notifications, subscriptions, and timelines.
 
+## [Events][]
+
+The [Events API][Events] is a read-only interface to all the [event
+types][types] that power the various activity streams on GitHub.
+
+## [Feeds][]
+
+List of [Atom feeds][Feeds] available for the authenticating user.
+
 ## [Notifications][]
 
 Notifications of new comments are delivered to users.  [The Notifications
@@ -22,18 +31,9 @@ have no effect on notifications or the activity feed.
 [Watching a Repository][Watching] registers the user to receive notifications on new
 discussions, as well as events in the user's activity feed.
 
-## [Events][]
-
-The [Events API][Events] is a read-only interface to all the [event
-types][types] that power the various activity streams on GitHub.
-
-## [Feeds][]
-
-List of [Atom feeds][Feeds] available for the authenticating user.
-
-[Notifications]: /v3/activity/notifications/
-[Starring]: /v3/activity/starring/
-[Watching]: /v3/activity/watching/
 [Events]: /v3/activity/events/
 [types]: /v3/activity/events/types/
 [Feeds]: /v3/activity/feeds/
+[Notifications]: /v3/activity/notifications/
+[Starring]: /v3/activity/starring/
+[Watching]: /v3/activity/watching/


### PR DESCRIPTION
Updated Activity page so that section descriptions match the order found in the contents selector on the side.

Just makes it a bit easier to browse the docs :thumbsup:.