### PR TITLE
Licensee cleanup

### DIFF
--- a/content/v3/licenses.md
+++ b/content/v3/licenses.md
@@ -55,7 +55,7 @@ When passed the preview media type, requests to get a repository will also retur
 
 It's important to note that the API simply attempts to identity the project's license by the contents of the a `LICENSE` file, if any, and does not take into account the licenses of project dependencies or other means of documenting a project's license such as references in the documentation.
 
-    GET /repos/github/hubot
+    GET /repos/:owner/:repo
 
 ### Response
 

--- a/layouts/sidebar.html
+++ b/layouts/sidebar.html
@@ -57,6 +57,7 @@
           <li><a href="/v3/markdown/">Markdown</a></li>
           <li><a href="/v3/meta/">Meta</a></li>
           <li><a href="/v3/rate_limit/">Rate Limit</a></li>
+          <li><a href="/v3/licenses/">Licenses</a></li>
         </ul>
       </li>
       <li class="js-topic">


### PR DESCRIPTION
* Adds Licenses to the API menu sidebar
* Refers to `:owner/:repo`, which is what we do across the API (e.g. `GET /repos/:owner/:repo/commits`)

/cc @github/docs-platform @benbalter 