### PR TITLE
OAuth api call for a token will not redirect

### DIFF
--- a/content/v3/oauth.md
+++ b/content/v3/oauth.md
@@ -53,7 +53,6 @@ Name | Type | Description
 `client_id`|`string` | **Required**. The client ID you received from GitHub when you [registered](https://github.com/settings/applications/new).
 `client_secret`|`string` | **Required**. The client secret you received from GitHub when you [registered](https://github.com/settings/applications/new).
 `code`|`string` | **Required**. The code you received as a response to [Step 1](#redirect-users-to-request-github-access).
-`redirect_uri`|`string` | The URL in your app where users will be sent after authorization. See details below about [redirect urls](#redirect-urls).
 
 ### Response
 


### PR DESCRIPTION
The api call for an OAuth token (`login/oauth/access_token`) will not redirect the user and thus should not need the `redirect_uri` parameter. The call before this one (letting the user authorize via `login/oauth/authorize`) will need it of course.

Or, do I misunderstand the process? In that case, it would be good to update the docs with the reason why the `redirect_uri` is needed.