### PR TITLE
Fixed typo in the "List feeds" description

### DIFF
--- a/content/changes/2012-12-06-create-authorization-for-app.html
+++ b/content/changes/2012-12-06-create-authorization-for-app.html
@@ -14,7 +14,7 @@ note and you get a token back:
          https://api.github.com/authorizations
 </pre>
 
-This call creates a token for the authenticating user tied to a special "API"
+This call creates a token for the authenticated user tied to a special "API"
 OAuth application.
 
 We now support creating tokens for _your own OAuth application_ by passing your

--- a/content/v3/activity.md
+++ b/content/v3/activity.md
@@ -13,7 +13,7 @@ types][types] that power the various activity streams on GitHub.
 
 ## [Feeds][]
 
-List of [Atom feeds][Feeds] available for the authenticating user.
+List of [Atom feeds][Feeds] available for the authenticated user.
 
 ## [Notifications][]
 

--- a/content/v3/activity/feeds.md
+++ b/content/v3/activity/feeds.md
@@ -10,7 +10,7 @@ title: Feeds | GitHub API
 ## List Feeds
 
 GitHub provides several timeline resources in [Atom][] format. The Feeds API
-lists all the feeds available to the authenticating user:
+lists all the feeds available to the authenticated user:
 
 * **Timeline**: The GitHub global public timeline
 * **User**: The public timeline for any user, using [URI template][]


### PR DESCRIPTION
Use "authenticated user" instead of "authenticating user".

---

In this context I'm almost sure it should be *authenticated user* (it's already used in the list below next to the description).

However there are [some other cases when this is used](https://github.com/github/developer.github.com/search?utf8=%E2%9C%93&q=authenticating+user).

 - https://github.com/github/developer.github.com/blob/9c97519f8cf8963305104fe18c8f67fef20295fb/content/changes/2012-12-06-create-authorization-for-app.html#L17
 - https://github.com/github/developer.github.com/blob/9c97519f8cf8963305104fe18c8f67fef20295fb/content/v3/activity.md#feeds

I will fix them too if you consider that. :smile: 