### PR TITLE
Use "revocable" instead of "revokable"

### DIFF
--- a/content/v3/activity/feeds.md
+++ b/content/v3/activity/feeds.md
@@ -20,7 +20,7 @@ lists all the feeds available to the authenticated user:
 * **Current user organizations**: The private timeline for the organizations the authenticated user is a member of.
 
 **Note**: Private feeds are only returned when [authenticating via Basic
-Auth][authenticating] since current feed URIs use the older, non revokable auth
+Auth][authenticating] since current feed URIs use the older, non revocable auth
 tokens.
 
     GET /feeds


### PR DESCRIPTION
Most probably that was a typo.

---

Apparently I learned [a new word](http://en.wiktionary.org/wiki/revokable), but I'm not sure how fine is that. :smile: 

![](http://i.stack.imgur.com/HK50c.png)