### PR TITLE
Fix missing name for inner deployment object

### DIFF
--- a/lib/webhooks/deployment.payload.json
+++ b/lib/webhooks/deployment.payload.json
@@ -5,6 +5,7 @@
     "sha": "69a8b72e2d3d955075d47f03d902929dcaf74033",
     "ref": "master",
     "task": "deploy",
+    "name": "baxterthehacker/public-repo",
     "payload": {
     },
     "environment": "production",


### PR DESCRIPTION
When hacking on heaven I noticed this small mistake.