### PR TITLE
Added note about acting user scope

### DIFF
--- a/content/v3/oauth.md
+++ b/content/v3/oauth.md
@@ -250,6 +250,10 @@ your application. More often than not, users will just close the window
 or press back in their browser, so it is likely that you'll never see
 this error.
 
+### Checking collaborators
+
+When requesting [repo collaborators](https://developer.github.com/v3/repos/collaborators/) the scope `public_repo` or `repo` is required otherwise Github will return `403 Forbidden: Must have push access to view repository collaborators.`.
+
 ## Common errors for the access token request
 
 In the second phase of exchanging a code for an access token, there are

--- a/content/v3/repos/collaborators.md
+++ b/content/v3/repos/collaborators.md
@@ -23,8 +23,6 @@ collaborators list.
 
 ## Check if a user is a collaborator {#get}
 
-User scope of `public_repo` or `repo` is required.
-
     GET /repos/:owner/:repo/collaborators/:username
 
 ### Response if user is a collaborator

--- a/content/v3/repos/collaborators.md
+++ b/content/v3/repos/collaborators.md
@@ -23,6 +23,8 @@ collaborators list.
 
 ## Check if a user is a collaborator {#get}
 
+User scope of `public_repo` or `repo` is required.
+
     GET /repos/:owner/:repo/collaborators/:username
 
 ### Response if user is a collaborator


### PR DESCRIPTION
Found out that that the scope `public_repo` or `repo` was required to make this api request properly. Otherwise the api results in 

```
403 Forbidden

{
  "message": "Must have push access to view repository collaborators.",
  "documentation_url": "https://developer.github.com/v3"
}
```

I hope this changes in the future. Adding this note to the documentation would have helped.