### PR TITLE
Clarify that draft releases can't be looked up by tag name

### DIFF
--- a/content/v3/repos/releases.md
+++ b/content/v3/repos/releases.md
@@ -57,7 +57,13 @@ View the latest published release for the repository.
 
 ## Get a release by tag name
 
-Get a release with the specified tag. Users must have push access to the repository to view draft releases.
+Get a release for the specified git tag.
+
+{{#tip}}
+
+Releases that are drafts usually don't have their git tag created yet, so they will have to be looked up by listing all releases for the repository. Only users with push access will receive listings for draft releases.
+
+{{/tip}}
 
     GET /repos/:owner/:repo/releases/tags/:tag
 


### PR DESCRIPTION
The previous documentation seemed to hint that you can look up a draft release by it's tag name (which is not yet a real git tag). This is not true, since the API will return 404 if the git tag name doesn't exist. The draft release will have to be looked up from the list of all releases.

/cc @github/api Does this make sense?