### PR TITLE
Explain `state` in "GitHub redirects back to your site" step of OAuth documentation

### DIFF
--- a/content/v3/oauth.md
+++ b/content/v3/oauth.md
@@ -54,6 +54,7 @@ Name | Type | Description
 `client_secret`|`string` | **Required**. The client secret you received from GitHub when you [registered](https://github.com/settings/applications/new).
 `code`|`string` | **Required**. The code you received as a response to [Step 1](#redirect-users-to-request-github-access).
 `redirect_uri`|`string` | The URL in your app where users will be sent after authorization. See details below about [redirect urls](#redirect-urls).
+`state`|`string` | The unguessable random string you optionally provided in [Step 1](#redirect-users-to-request-github-access).
 
 ### Response
 


### PR DESCRIPTION
What it says on the tin.