### PR TITLE
Clarify instructions for /forks endpoint.

### DIFF
--- a/content/v3/repos/forks.md
+++ b/content/v3/repos/forks.md
@@ -29,14 +29,11 @@ Create a fork for the authenticated user.
 
     POST /repos/:owner/:repo/forks
 
-If you are creating a fork for an organization, use the optional `organization` parameter or POST a JSON document with
-the field `organization`
-
 ### Parameters
 
 Name | Type | Description
 -----|------|-------------
-`organization`|`string` | The organization login. The repository will be forked into this organization.
+`organization`|`string` | Optional parameter to specify the organization name if forking into an organization.
 
 
 ### Response

--- a/content/v3/repos/forks.md
+++ b/content/v3/repos/forks.md
@@ -29,7 +29,7 @@ Create a fork for the authenticated user.
 
     POST /repos/:owner/:repo/forks
 
-One can either use the `organization` parameter or POST a JSON document with
+If you are creating a fork for an organization, use the optional `organization` parameter or POST a JSON document with
 the field `organization`
 
 ### Parameters


### PR DESCRIPTION
The existing text isn't clear as to whether the `organization` parameter is optional. This can lead to people assuming the parameter isn't optional and doing `organization=username`, which will not work.