### PR TITLE
Adds the tip for preview media type for Enterprise 2.2

### DIFF
--- a/enterprise/2.2/v3/orgs/hooks/index.html
+++ b/enterprise/2.2/v3/orgs/hooks/index.html
@@ -66,6 +66,21 @@
   <li><a href="#receiving-webhooks">Receiving Webhooks</a></li>
 </ul>
 
+<div class="alert tip">
+
+<p><a name="preview-period"></a></p>
+
+<p>The Organization Webhooks API is currently available for developers to preview.
+  During the preview period, the API may change without advance notice.
+  Please see the <a href="/enterprise/2.1/changes/2014-12-03-preview-the-new-organization-webhooks-api/">blog post</a> for full details.</p>
+
+<p>To access the API during the preview period, you must provide a custom <a href="/enterprise/2.1/v3/media">media type</a> in the <code>Accept</code> header:</p>
+
+<pre><code>  application/vnd.github.sersi-preview+json
+</code></pre>
+
+</div>
+
 <p>Organization webhooks allow you to receive HTTP <code>POST</code> payloads whenever certain events happen within the organization. Subscribing to these events makes it possible to build integrations that react to actions on GitHub.com. For more information on actions you can subscribe to, check out our <a href="/enterprise/2.2/webhooks/#events">Events documentation</a>.</p>
 
 <h2 id="scopes--restrictions">Scopes &amp; Restrictions</h2>

--- a/enterprise/2.2/v3/orgs/hooks/index.html
+++ b/enterprise/2.2/v3/orgs/hooks/index.html
@@ -72,9 +72,9 @@
 
 <p>The Organization Webhooks API is currently available for developers to preview.
   During the preview period, the API may change without advance notice.
-  Please see the <a href="/enterprise/2.1/changes/2014-12-03-preview-the-new-organization-webhooks-api/">blog post</a> for full details.</p>
+  Please see the <a href="/enterprise/2.2/changes/2014-12-03-preview-the-new-organization-webhooks-api/">blog post</a> for full details.</p>
 
-<p>To access the API during the preview period, you must provide a custom <a href="/enterprise/2.1/v3/media">media type</a> in the <code>Accept</code> header:</p>
+<p>To access the API during the preview period, you must provide a custom <a href="/enterprise/2.2/v3/media">media type</a> in the <code>Accept</code> header:</p>
 
 <pre><code>  application/vnd.github.sersi-preview+json
 </code></pre>


### PR DESCRIPTION
The organization webhooks API on GitHub Enterprise still require the custom media type to be passed along with the request. This is noted for [v2.1](https://developer.github.com/enterprise/2.1/v3/orgs/hooks/) and below, but is missing for [v2.2](https://developer.github.com/enterprise/2.2/v3/orgs/hooks/).

This PR adds the tip to the static Enterprise 2.2 docs.

/cc @gjtorikian @github/docs-platform 