### PR TITLE
duplicate sentence from paragraph above

### DIFF
--- a/content/v3/oauth.md
+++ b/content/v3/oauth.md
@@ -17,8 +17,6 @@ All developers need to [register their
 application](https://github.com/settings/applications/new) before getting
 started. A registered OAuth application is assigned a unique Client ID
 and Client Secret. The Client Secret should not be shared.
-This is preferred over Basic Authentication because tokens can be limited
-to specific types of data, and can be revoked by users at any time.
 **You may create a [personal access token](https://github.com/settings/tokens/new)
 for your own use or implement the web flow below to allow other users to authorize your application.**
 


### PR DESCRIPTION
The exact same sentence is used in the previous paragraph to explain why oauth is preferred over basic auth