### PR TITLE
Indent verbs all the way

### DIFF
--- a/content/v3/users/administration.md
+++ b/content/v3/users/administration.md
@@ -64,7 +64,7 @@ Name | Type | Description
 
 ## Create an impersonation OAuth token
 
-  POST /admin/users/:user_id/authorizations
+    POST /admin/users/:user_id/authorizations
 
 ### Parameters
 
@@ -79,7 +79,7 @@ Name | Type | Description
 
 ## Delete an impersonation OAuth token
 
-  DELETE /admin/users/:user_id/authorizations
+    DELETE /admin/users/:user_id/authorizations
 
 ### Response
 


### PR DESCRIPTION
I noticed the verb + endpoints weren't rendering as `pre` tags:

<img width="492" alt="image 2015-08-12 at 8 25 29 pm" src="https://cloud.githubusercontent.com/assets/64050/9242080/f80ad70e-4130-11e5-90fd-0393a9bed903.png">

This PR pushes them in by a couple of spaces.

/cc @github/platform 