### PR TITLE
Add new library for Scala, Buhtig

### DIFF
--- a/content/libraries.md
+++ b/content/libraries.md
@@ -186,9 +186,11 @@ covers the entire API.
 
 * [Dispatch GitHub][dispatchgithub]
 * [Hubcat][hubcat]
+* [Buhtig][buhtig]
 
 [dispatchgithub]: https://github.com/andreazevedo/dispatch-github
 [hubcat]: https://github.com/softprops/hubcat
+[buhtig]: https://github.com/mdread/buhtig
 
 ## Shell
 


### PR DESCRIPTION
Added a link in the libraries page to a scala implementation of the api ([Buhtig](https://github.com/mdread/buhtig))