### PR TITLE
Set the encoding to be used to utf-8

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -29,6 +29,9 @@ data_sources:
     # `filesystem_unified`.
     type: filesystem_unified
 
+    # The encoding to be used (on Windows this is not utf-8 by default)
+    encoding: utf-8
+
     # The path where items should be mounted (comparable to mount points in
     # Unix-like systems). This is “/” by default, meaning that items will have
     # “/” prefixed to their identifiers. If the items root were “/en/”


### PR DESCRIPTION
Haha, finally got Ruby working on Windows.

This ensures a consistent authoring model, since everyone likes consistency.

|           good           |               bad              |
|-------------------------|-----------------------------|
|![image][left home] | ![image][right home]  |

[left home]: https://cloud.githubusercontent.com/assets/4105066/9944079/6138de36-5d85-11e5-9b58-662e478294a3.png
[right home]: https://cloud.githubusercontent.com/assets/4105066/9944151/be4358ae-5d85-11e5-8a67-fd56c2925c91.png