### PR TITLE
Document alternative .terminal block syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,18 +77,27 @@ Some actions return arrays.  You can modify the JSON by passing a block:
 
 ### Terminal blocks
 
-You can specify terminal blocks with `pre.terminal` elements.  (It'd be nice if
-Markdown could do this more cleanly.)
+You can specify terminal blocks by prefacing a [block element][block boundaries] with `{:.terminal}`.
+
+```markdown
+{:.terminal}
+    $ curl foobar
+```
+
+Alternatively, you can use plain html and use `pre.terminal` elements.
+(If, for example, you need to emphasis text with `<em>`)
 
 ```html
 <pre class="terminal">
-$ curl foobar
+$ curl <em>foobar<em>
 ....
 </pre>
 ```
 
 This is not a `curl` tutorial though. Not every API call needs
 to show how to access it with `curl`.
+
+[block boundaries]: http://kramdown.gettalong.org/syntax.html#block-boundaries
 
 ## Development
 

--- a/content/changes/2012-10-24-set-default-branch.html
+++ b/content/changes/2012-10-24-set-default-branch.html
@@ -11,11 +11,10 @@ You can set the default branch for a repository to something other than 'master'
 
 Now, you can update this setting via the API. We've added a `default_branch` parameter to the [Edit Repository method][edit-repo]:
 
-<pre class="terminal">
-curl -u pengwynn \
-     -d '{"name": "octokit", "default_branch":"development"}' \
-     https://api.github.com/repos/octokit/octokit.rb
-</pre>
+{:.terminal}
+    curl -u pengwynn \
+         -d '{"name": "octokit", "default_branch":"development"}' \
+         https://api.github.com/repos/octokit/octokit.rb
 
 If you provide a branch name that hasn't been pushed to GitHub, we'll gracefully fall back to `'master'` or the first branch.
 

--- a/content/changes/2012-10-26-notifications-api.md
+++ b/content/changes/2012-10-26-notifications-api.md
@@ -17,55 +17,50 @@ view and mark notifications as read.
 The core notifications functionality is under the `/notifications` endpoint.
 You can look for unread notifications:
 
-<pre class="terminal">
-$ curl https://api.github.com/notifications
-</pre>
+{:.terminal}
+    $ curl https://api.github.com/notifications
 
 You can filter these notifications to a single Repository:
 
-<pre class="terminal">
-$ curl https://api.github.com/repos/technoweenie/faraday/notifications
-</pre>
+{:.terminal}
+    $ curl https://api.github.com/repos/technoweenie/faraday/notifications
 
 You can mark them as read:
 
-<pre class="terminal">
-# all notifications
-$ curl https://api.github.com/notifications \
-    -X PUT -d '{"read": true}'
+{:.terminal}
+    # all notifications
+    $ curl https://api.github.com/notifications \
+        -X PUT -d '{"read": true}'
 
-# notifications for a single repository
-$ curl https://api.github.com/repos/technoweenie/faraday/notifications \
-    -X PUT -d '{"read": true}'
-</pre>
+    # notifications for a single repository
+    $ curl https://api.github.com/repos/technoweenie/faraday/notifications \
+        -X PUT -d '{"read": true}'
 
 You can also modify subscriptions for a Repository or a single thread.
 
-<pre class="terminal">
-# subscription details for the thread (either an Issue or Commit)
-$ curl https://api.github.com/notifications/threads/1/subscription
+{:.terminal}
+    # subscription details for the thread (either an Issue or Commit)
+    $ curl https://api.github.com/notifications/threads/1/subscription
 
-# subscription details for a whole Repository.
-$ curl https://api.github.com/repos/technoweenie/faraday/subscription
-</pre>
+    # subscription details for a whole Repository.
+    $ curl https://api.github.com/repos/technoweenie/faraday/subscription
 
 ## Polling
 
 The Notifications API is optimized for polling by the last modified time:
 
-<pre class="terminal">
-# Add authentication to your requests
-$ curl -I https://api.github.com/notifications
-HTTP/1.1 200 OK
-Last-Modified: Thu, 25 Oct 2012 15:16:27 GMT
-X-Poll-Interval: 60
+{:.terminal}
+    # Add authentication to your requests
+    $ curl -I https://api.github.com/notifications
+    HTTP/1.1 200 OK
+    Last-Modified: Thu, 25 Oct 2012 15:16:27 GMT
+    X-Poll-Interval: 60
 
-# Pass the Last-Modified header exactly
-$ curl -I https://api.github.com/notifications
-    -H "If-Modified-Since: Thu, 25 Oct 2012 15:16:27 GMT"
-HTTP/1.1 304 Not Modified
-X-Poll-Interval: 60
-</pre>
+    # Pass the Last-Modified header exactly
+    $ curl -I https://api.github.com/notifications
+        -H "If-Modified-Since: Thu, 25 Oct 2012 15:16:27 GMT"
+    HTTP/1.1 304 Not Modified
+    X-Poll-Interval: 60
 
 You can read about the API details in depth in the [Notifications documentation][api].
 

--- a/content/changes/2012-11-27-forking-to-organizations.html
+++ b/content/changes/2012-11-27-forking-to-organizations.html
@@ -8,12 +8,14 @@ author_name: technoweenie
 We made a slight change to the way you fork a repository.  By default, you
 can fork my repository through an HTTP POST to the repository's fork resource.
 
+{:.terminal}
     $ curl -X POST https://api.github.com/repos/technoweenie/faraday/forks
 
 This repository forks to your personal account.  However, there are cases when
 you want to fork to one of your organizations instead.  The previous method
 required a `?org` query parameter:
 
+{:.terminal}
     $ curl -X POST /repos/technoweenie/faraday/forks?org=mycompany
 
 Query parameters on POST requests are unusual in APIs, and definitely
@@ -21,6 +23,7 @@ inconsistent with the rest of the GitHub API.  You should be able to post a
 JSON body like every other POST endpoint.  Now, you can!  Only, now we're
 calling the field `organization`.
 
+{:.terminal}
     $ curl /repos/technoweenie/faraday/forks?org=mycompany \
       -d '{"organization": "mycompany"}'
 

--- a/content/changes/2012-11-29-gitignore-templates.html
+++ b/content/changes/2012-11-29-gitignore-templates.html
@@ -12,6 +12,7 @@ templates from the the public [GitHub .gitignore repository][templates-repo].
 
 The [Gitignore Templates API][new-api] makes it easy to list those templates:
 
+{:.terminal}
     curl https://api.github.com/gitignore/templates
 
     HTTP/1.1 200 OK
@@ -28,6 +29,7 @@ The [Gitignore Templates API][new-api] makes it easy to list those templates:
 
 If you'd like to view the source, you can also fetch a single template.
 
+{:.terminal}
     curl -H 'Accept: application/vnd.github.raw' \
          https://api.github.com/gitignore/templates/Objective-C
 

--- a/content/changes/2012-12-04-List-comments-for-repo.html
+++ b/content/changes/2012-12-04-List-comments-for-repo.html
@@ -12,6 +12,7 @@ Comments, you could only fetch the comments for a single Issue or Pull Request.
 Today, we're introducing two new methods to grab all Issue Comments and Review
 Comments for a repository.
 
+{:.terminal}
     # Grab all Issue Comments
     curl https://api.github.com/repos/mathiasbynens/dotfiles/issues/comments
 

--- a/content/changes/2012-12-06-create-authorization-for-app.html
+++ b/content/changes/2012-12-06-create-authorization-for-app.html
@@ -9,10 +9,9 @@ The [Authorizations API][oauth-api] is an easy way to create an OAuth
 authorization using Basic Auth. Just POST your desired scopes and optional
 note and you get a token back:
 
-<pre class='terminal'>
+{:.terminal}
     curl -u pengwynn -d '{"scopes": ["user", "gist"]}' \
          https://api.github.com/authorizations
-</pre>
 
 This call creates a token for the authenticated user tied to a special "API"
 OAuth application.
@@ -22,14 +21,13 @@ twenty character `client_id` and forty character `client_secret` as found in
 the settings page for your OAuth application.
 
 
-<pre class='terminal'>
+{:.terminal}
     curl -u pengwynn -d '{ \
                           "scopes": ["user", "gist"], \
                           "client_id": "abcdeabcdeabcdeabcdeabcde" \
                           "client_secret": "abcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcde" \
                          }' \ '
             https://api.github.com/authorizations
-</pre>
 
 No more implementing the [web flow][web-flow] just to get a token tied to your
 app's rate limit.

--- a/content/changes/2012-12-08-finding-source-and-fork-repos-for-organizations.html
+++ b/content/changes/2012-12-08-finding-source-and-fork-repos-for-organizations.html
@@ -11,6 +11,7 @@ Organization repositories tab.  We now let you retrieve repositories
 which are forks of another repository, as well as those repositories which
 are sources (not forks).
 
+{:.terminal}
     # Grab all fork Repositories for an Organization
     curl "https://api.github.com/orgs/:org/repos?type=forks"
 

--- a/content/changes/2012-12-10-Diff-and-patch-media-types.html
+++ b/content/changes/2012-12-10-Diff-and-patch-media-types.html
@@ -13,6 +13,7 @@ Starting today, you can get `.diff` and `.patch` content directly from the API f
 
 Simply use the same resource URL and send either `application/vnd.github.diff` or `application/vnd.github.patch` in the `Accept` header:
 
+{:.terminal}
     curl -H "Accept: application/vnd.github.diff" https://api.github.com/repos/pengwynn/dotfiles/commits/aee60a4cd56fb4c6a50e60f17096fc40c0d4d72c
 
     diff --git a/tmux/tmux.conf.symlink b/tmux/tmux.conf.symlink

--- a/content/changes/2012-9-28-auto-init-for-repositories.html
+++ b/content/changes/2012-9-28-auto-init-for-repositories.html
@@ -13,11 +13,10 @@ the API.
 Now you can optionally init a repository when it's created by sending `true`
 for the `auto_init` parameter:
 
-<pre class="terminal">
-curl -i -u pengwynn \
-     -d '{"name": "create-repo-test", "auto_init": true}' \
-     https://api.github.com/user/repos
-</pre>
+{:.terminal}
+    curl -i -u pengwynn \
+         -d '{"name": "create-repo-test", "auto_init": true}' \
+         https://api.github.com/user/repos
 
 The resulting repository will have a README stub and an initial commit.
 
@@ -29,12 +28,11 @@ Along with this change, you can set up your `.gitignore` template by passing
 the basename of any template in the [GitHub gitignore templates
 project](https://github.com/github/gitignore).
 
-<pre class="terminal">
-curl -i -u pengwynn \
-     -d '{"name": "create-repo-test", "auto_init": true, \
-          "gitignore_template": "Haskell"}' \
-     https://api.github.com/user/repos
-</pre>
+{:.terminal}
+    curl -i -u pengwynn \
+         -d '{"name": "create-repo-test", "auto_init": true, \
+              "gitignore_template": "Haskell"}' \
+         https://api.github.com/user/repos
 
 
 As the [docs point out](/v3/repos/#create), the `gitignore_template` parameter

--- a/content/changes/2012-9-5-watcher-api.html
+++ b/content/changes/2012-9-5-watcher-api.html
@@ -53,6 +53,7 @@ requests pass that value for the "Accept" header.  You should do this now.  This
 can be verified by checking the `X-GitHub-Media-Type` header on all API
 responses.
 
+{:.terminal}
     # Accesses a user's starred repositories.
     curl https://api.github.com/user/watched \
       -H "Accept: application/vnd.github.beta+json"

--- a/content/changes/2013-04-30-improved-submodule-support-in-repository-contents-api.md
+++ b/content/changes/2013-04-30-improved-submodule-support-in-repository-contents-api.md
@@ -11,26 +11,25 @@ When you view a repository with a submodule on github.com, you get useful links 
 
 Today we're making that data available in the [Repository Contents API][docs].
 
-<pre class="terminal">
-curl https://api.github.com/repos/jquery/jquery/contents/test/qunit
+{:.terminal}
+    curl https://api.github.com/repos/jquery/jquery/contents/test/qunit
 
-{
-  "name": "qunit",
-  "path": "test/qunit",
-  "type": "submodule",
-  "submodule_git_url": "git://github.com/jquery/qunit.git",
-  "sha": "6ca3721222109997540bd6d9ccd396902e0ad2f9",
-  "size": 0,
-  "url": "https://api.github.com/repos/jquery/jquery/contents/test/qunit?ref=master",
-  "git_url": "https://api.github.com/repos/jquery/qunit/git/trees/6ca3721222109997540bd6d9ccd396902e0ad2f9",
-  "html_url": "https://github.com/jquery/qunit/tree/6ca3721222109997540bd6d9ccd396902e0ad2f9",
-  "_links": {
-    "self": "https://api.github.com/repos/jquery/jquery/contents/test/qunit?ref=master",
-    "git": "https://api.github.com/repos/jquery/qunit/git/trees/6ca3721222109997540bd6d9ccd396902e0ad2f9",
-    "html": "https://github.com/jquery/qunit/tree/6ca3721222109997540bd6d9ccd396902e0ad2f9"
-  }
-}
-</pre>
+    {
+      "name": "qunit",
+      "path": "test/qunit",
+      "type": "submodule",
+      "submodule_git_url": "git://github.com/jquery/qunit.git",
+      "sha": "6ca3721222109997540bd6d9ccd396902e0ad2f9",
+      "size": 0,
+      "url": "https://api.github.com/repos/jquery/jquery/contents/test/qunit?ref=master",
+      "git_url": "https://api.github.com/repos/jquery/qunit/git/trees/6ca3721222109997540bd6d9ccd396902e0ad2f9",
+      "html_url": "https://github.com/jquery/qunit/tree/6ca3721222109997540bd6d9ccd396902e0ad2f9",
+      "_links": {
+        "self": "https://api.github.com/repos/jquery/jquery/contents/test/qunit?ref=master",
+        "git": "https://api.github.com/repos/jquery/qunit/git/trees/6ca3721222109997540bd6d9ccd396902e0ad2f9",
+        "html": "https://github.com/jquery/qunit/tree/6ca3721222109997540bd6d9ccd396902e0ad2f9"
+      }
+    }
 
 If you have any questions or feedback, please drop us a line at
 [support@github.com](mailto:support@github.com?subject=Submodules in Repository Contents API).

--- a/content/changes/2013-04-30-statuses-for-branches-and-tags.md
+++ b/content/changes/2013-04-30-statuses-for-branches-and-tags.md
@@ -9,9 +9,8 @@ Last week we announced [support for build statuses in the branches page][blog].
 Now we are extending this to the API. The [API endpoint for commit statuses][doc]
 has been extended to allow branch and tag names, as well as commit SHAs.
 
-<pre class="terminal">
-curl https://api.github.com/repos/rails/rails/statuses/3-2-stable
-</pre>
+{:.terminal}
+    curl https://api.github.com/repos/rails/rails/statuses/3-2-stable
 
 Enjoy.
 

--- a/content/changes/2013-07-01-feeds-api.md
+++ b/content/changes/2013-07-01-feeds-api.md
@@ -8,46 +8,43 @@ author_name: pengwynn
 Today we're releasing a new [Feeds API][], an easy way to list all the Atom
 resources available to the authenticated user.
 
-<pre class='terminal'>
+{:.terminal}
+    curl -u defunkt https://api.github.com/feeds
 
-curl -u defunkt https://api.github.com/feeds
-
-{
-  "timeline_url": "https://github.com/timeline",
-  "user_url": "https://github.com/{user}",
-  "current_user_public_url": "https://github.com/defunkt",
-  "current_user_url": "https://github.com/defunkt.private?token=abc123",
-  "current_user_actor_url": "https://github.com/defunkt.private.actor?token=abc123",
-  "current_user_organization_url": "https://github.com/organizations/{org}/defunkt.private.atom?token=abc123",
-  "_links": {
-    "timeline": {
-      "href": "https://github.com/timeline",
-      "type": "application/atom+xml"
-    },
-    "user": {
-      "href": "https://github.com/{user}",
-      "type": "application/atom+xml"
-    },
-    "current_user_public": {
-      "href": "https://github.com/defunkt",
-      "type": "application/atom+xml"
-    },
-    "current_user": {
-      "href": "https://github.com/defunkt.private?token=abc123",
-      "type": "application/atom+xml"
-    },
-    "current_user_actor": {
-      "href": "https://github.com/defunkt.private.actor?token=abc123",
-      "type": "application/atom+xml"
-    },
-    "current_user_organization": {
-      "href": "https://github.com/organizations/{org}/defunkt.private.atom?token=abc123",
-      "type": "application/atom+xml"
+    {
+      "timeline_url": "https://github.com/timeline",
+      "user_url": "https://github.com/{user}",
+      "current_user_public_url": "https://github.com/defunkt",
+      "current_user_url": "https://github.com/defunkt.private?token=abc123",
+      "current_user_actor_url": "https://github.com/defunkt.private.actor?token=abc123",
+      "current_user_organization_url": "https://github.com/organizations/{org}/defunkt.private.atom?token=abc123",
+      "_links": {
+        "timeline": {
+          "href": "https://github.com/timeline",
+          "type": "application/atom+xml"
+        },
+        "user": {
+          "href": "https://github.com/{user}",
+          "type": "application/atom+xml"
+        },
+        "current_user_public": {
+          "href": "https://github.com/defunkt",
+          "type": "application/atom+xml"
+        },
+        "current_user": {
+          "href": "https://github.com/defunkt.private?token=abc123",
+          "type": "application/atom+xml"
+        },
+        "current_user_actor": {
+          "href": "https://github.com/defunkt.private.actor?token=abc123",
+          "type": "application/atom+xml"
+        },
+        "current_user_organization": {
+          "href": "https://github.com/organizations/{org}/defunkt.private.atom?token=abc123",
+          "type": "application/atom+xml"
+        }
+      }
     }
-  }
-}
-
-</pre>
 
 If you have any questions or feedback, [please drop us a line][contact].
 

--- a/content/changes/2013-07-02-rate-limit-reset.md
+++ b/content/changes/2013-07-02-rate-limit-reset.md
@@ -8,32 +8,30 @@ author_name: jasonrudolph
 Have you ever wondered when your [rate limit][rate-limit-docs] will reset back to its maximum value?
 That information is now available in the new `X-RateLimit-Reset` response header.
 
-<pre class="terminal">
-$ curl -I https://api.github.com/orgs/octokit
+{:.terminal}
+    $ curl -I https://api.github.com/orgs/octokit
 
-HTTP/1.1 200 OK
-Status: 200 OK
-X-RateLimit-Limit: 60
-X-RateLimit-Remaining: 42
-X-RateLimit-Reset: 1372700873
-...
-</pre>
+    HTTP/1.1 200 OK
+    Status: 200 OK
+    X-RateLimit-Limit: 60
+    X-RateLimit-Remaining: 42
+    X-RateLimit-Reset: 1372700873
+    ...
 
 The `X-RateLimit-Reset` header provides a [Unix UTC timestamp][unix-time], letting you know the exact time that your fresh new rate limit kicks in.
 
 The reset timestamp is also available as part of the `/rate_limit` resource.
 
-<pre class="terminal">
-$ curl https://api.github.com/rate_limit
+{:.terminal}
+    $ curl https://api.github.com/rate_limit
 
-{
-  "rate": {
-    "limit": 60,
-    "remaining": 42,
-    "reset": 1372700873
-  }
-}
-</pre>
+    {
+      "rate": {
+        "limit": 60,
+        "remaining": 42,
+        "reset": 1372700873
+      }
+    }
 
 For more information on rate limits, be sure to check out the [docs][rate-limit-docs].
 

--- a/content/changes/2013-09-25-releases-api.md
+++ b/content/changes/2013-09-25-releases-api.md
@@ -11,38 +11,35 @@ This summer we made it easier to [release your software][blawg].  Today, you can
 This API is a little different due to the binary assets.  We use the `Accept` header for content negotiation when requesting
 a release asset.  Pass a standard API media type to get the API representation:
 
-<pre class="terminal">
-$ curl -i -H "Authorization: token TOKEN" \
-     -H "Accept: application/vnd.github.manifold-preview" \
-     "https://uploads.github.com/repos/hubot/singularity/releases/assets/123"
+{:.terminal}
+    $ curl -i -H "Authorization: token TOKEN" \
+         -H "Accept: application/vnd.github.manifold-preview" \
+         "https://uploads.github.com/repos/hubot/singularity/releases/assets/123"
 
-HTTP/1.1 200 OK
+    HTTP/1.1 200 OK
 
-{
-  "id": 123,
-  ...
-}
-</pre>
+    {
+      "id": 123,
+      ...
+    }
 
 Pass "application/octet-stream" to download the binary content.
 
-<pre class="terminal">
-$ curl -i -H "Authorization: token TOKEN" \
-     -H "Accept: application/octet-stream" \
-     "https://uploads.github.com/repos/hubot/singularity/releases/assets/123"
+{:.terminal}
+    $ curl -i -H "Authorization: token TOKEN" \
+         -H "Accept: application/octet-stream" \
+         "https://uploads.github.com/repos/hubot/singularity/releases/assets/123"
 
-HTTP/1.1 302 Found
-</pre>
+    HTTP/1.1 302 Found
 
 Uploads are handled by a single request to a companion "uploads.github.com" service.
 
-<pre class="terminal">
-$ curl -H "Authorization: token TOKEN" \
-     -H "Accept: application/vnd.github.manifold-preview" \
-     -H "Content-Type: application/zip" \
-     --data-binary @build/mac/package.zip \
-     "https://uploads.github.com/repos/hubot/singularity/releases/123/assets?name=1.0.0-mac.zip"
-</pre>
+{:.terminal}
+    $ curl -H "Authorization: token TOKEN" \
+         -H "Accept: application/vnd.github.manifold-preview" \
+         -H "Content-Type: application/zip" \
+         --data-binary @build/mac/package.zip \
+         "https://uploads.github.com/repos/hubot/singularity/releases/123/assets?name=1.0.0-mac.zip"
 
 ## Preview mode
 

--- a/content/changes/2013-10-08-list-all-user-teams.html
+++ b/content/changes/2013-10-08-list-all-user-teams.html
@@ -8,34 +8,33 @@ author_name: pengwynn
 We just added a [new API method](/v3/orgs/teams/#list-user-teams) to list all
 the teams for the authenticated user across all organizations:
 
-<pre class="terminal">
-$ curl -H "Authorization: token [yours]" https://api.github.com/user/teams
+{:.terminal}
+    $ curl -H "Authorization: token [yours]" https://api.github.com/user/teams
 
-[
-  {
-    "name": "Testing",
-    "id": 396018,
-    "slug": "testing",
-    "permission": "pull",
-    "url": "https://api.github.com/teams/396018",
-    "members_url": "https://api.github.com/teams/396018/members{/member}",
-    "repositories_url": "https://api.github.com/teams/396018/repos",
-    "members_count": 1,
-    "repos_count": 0,
-    "organization": {
-      "login": "dotfiles",
-      "id": 1593590,
-      "url": "https://api.github.com/orgs/dotfiles",
-      "repos_url": "https://api.github.com/orgs/dotfiles/repos",
-      "events_url": "https://api.github.com/orgs/dotfiles/events",
-      "members_url": "https://api.github.com/orgs/dotfiles/members{/member}",
-      "public_members_url": "https://api.github.com/orgs/dotfiles/public_members{/member}",
-      "avatar_url": "https://0.gravatar.com/avatar/67d30facf213f62853c119fc2a05e246?d=https%3A%2F%2Fidenticons.github.com%2Fc90a68e6ab739e81c642f0e93f88c722.png"
-    }
-  },
-  ...
-]
-</pre>
+    [
+      {
+        "name": "Testing",
+        "id": 396018,
+        "slug": "testing",
+        "permission": "pull",
+        "url": "https://api.github.com/teams/396018",
+        "members_url": "https://api.github.com/teams/396018/members{/member}",
+        "repositories_url": "https://api.github.com/teams/396018/repos",
+        "members_count": 1,
+        "repos_count": 0,
+        "organization": {
+          "login": "dotfiles",
+          "id": 1593590,
+          "url": "https://api.github.com/orgs/dotfiles",
+          "repos_url": "https://api.github.com/orgs/dotfiles/repos",
+          "events_url": "https://api.github.com/orgs/dotfiles/events",
+          "members_url": "https://api.github.com/orgs/dotfiles/members{/member}",
+          "public_members_url": "https://api.github.com/orgs/dotfiles/public_members{/member}",
+          "avatar_url": "https://0.gravatar.com/avatar/67d30facf213f62853c119fc2a05e246?d=https%3A%2F%2Fidenticons.github.com%2Fc90a68e6ab739e81c642f0e93f88c722.png"
+        }
+      },
+      ...
+    ]
 
 As always, if you have any questions or feedback, please [drop us a line][contact].
 

--- a/content/changes/2013-2-13-sortable-stars.html
+++ b/content/changes/2013-2-13-sortable-stars.html
@@ -9,9 +9,8 @@ As we [announced on the GitHub blog][post], Stars now support sorting. The
 Repository Starring API now supports [two new parameters][params] when listing
 Stars: `sort` and `direction`.
 
-<pre class='terminal'>
-curl https://api.github.com/users/defunkt/starred?sort=created&direction=asc
-</pre>
+{:.terminal}
+    curl https://api.github.com/users/defunkt/starred?sort=created&direction=asc
 
 Enjoy.
 

--- a/content/changes/2014-01-29-audit-org-members-for-2fa.md
+++ b/content/changes/2014-01-29-audit-org-members-for-2fa.md
@@ -9,10 +9,9 @@ We've added a [new filter][filter] for listing members of an organization withou
 [two-factor authentication][2fa-blog] enabled:
 
 
-<pre class="terminal">
-$ curl -H "Authorization: token [yours]" \
-       "https://api.github.com/orgs/[orgname]/members?filter=2fa_disabled"
-</pre>
+{:.terminal}
+    $ curl -H "Authorization: token [yours]" \
+           "https://api.github.com/orgs/[orgname]/members?filter=2fa_disabled"
 
 The new filter is available for owners of organizations with private
 repositories. Happy auditing and [send us your feedback or questions][contact].

--- a/content/changes/2014-02-28-issue-and-pull-query-enhancements.md
+++ b/content/changes/2014-02-28-issue-and-pull-query-enhancements.md
@@ -8,17 +8,15 @@ We've made it even easier to list all [issues][] and [pull requests][] via the A
 The `state` parameter now supports a value of `all` that will return issues and
 pull requests regardless of state.
 
-<pre class="terminal">
-$ curl https://api.github.com/repos/atom/vim-mode/issues\?state\=all
-</pre>
+{:.terminal}
+    $ curl https://api.github.com/repos/atom/vim-mode/issues\?state\=all
 
 We've also introduced new sorting options for [listing pull requests][pull
 requests]. You can now sort pull requests by `created`, `updated`,
 `popularity`, and `long-running`.
 
-<pre class="terminal">
-$ curl https://api.github.com/repos/rails/rails/pulls\?sort\=long-running\&direction\=desc
-</pre>
+{:.terminal}
+    $ curl https://api.github.com/repos/rails/rails/pulls\?sort\=long-running\&direction\=desc
 
 Happy querying. If you have any questions or feedback [get in touch][contact].
 

--- a/content/changes/2014-03-04-timezone-handling-changes.html
+++ b/content/changes/2014-03-04-timezone-handling-changes.html
@@ -30,6 +30,7 @@ for specifying the `date` property.
 It is possible to supply a `Time-Zone` header which defines a timezone according
 to the [list of names from the Olson database](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones).
 
+{:.terminal}
     $ curl -H "Time-Zone: Europe/Amsterdam" -X POST https://api.github.com/repos/github/linguist/contents/new_file.md
 
 This means that we generate a timestamp for the moment your API call is made in

--- a/content/changes/2014-08-15-deployments-api-changes.md
+++ b/content/changes/2014-08-15-deployments-api-changes.md
@@ -11,10 +11,9 @@ We've added two new features to the [Deployments API preview][deployments-previe
 
 You can now search for deployments via query parameters to the [listing endpoint][listing-endpoint]. You can filter on `sha`, `ref`, `task`, and `environment`. This makes it easier to answer questions like "when was the last time someone deployed to staging?"
 
-<pre class="terminal">
-$ curl -H "Authorization: token [yours]" \
-       https://api.github.com/repos/octocat/my-repo/deployments?environment=staging
-</pre>
+{:.terminal}
+    $ curl -H "Authorization: token [yours]" \
+           https://api.github.com/repos/octocat/my-repo/deployments?environment=staging
 
 ## New attribute
 

--- a/content/changes/2014-12-09-new-attributes-for-stars-api.md
+++ b/content/changes/2014-12-09-new-attributes-for-stars-api.md
@@ -7,6 +7,7 @@ author_name: arfon
 
 You can now see when a user starred a repository. To receive the new response format containing the `starred_at` field, request the new media type:
 
+{:.terminal}
     curl -H "Accept: application/vnd.github.v3.star+json" https://api.github.com/users/andrew/starred
 
 Note the starred repository is now available in the repo field.

--- a/content/changes/2015-06-11-pages-a-records.md
+++ b/content/changes/2015-06-11-pages-a-records.md
@@ -7,9 +7,8 @@ author_name: leereilly
 
 The [Meta API](/v3/meta/) now includes the A record IP addresses for [GitHub Pages](https://pages.github.com/).
 
-<pre class="terminal">
-$ curl https://api.github.com/meta
-</pre>
+{:.terminal}
+    $ curl https://api.github.com/meta
 
 <pre><code class="language-javascript">
 {

--- a/content/changes/2015-06-17-organizations-endpoint.md
+++ b/content/changes/2015-06-17-organizations-endpoint.md
@@ -7,24 +7,23 @@ author_name: keavy
 
 We've added a [new API method](/v3/orgs#list-all-organizations) to list all organizations:
 
-<pre class="terminal">
-$ curl https://api.github.com/organizations
+{:.terminal}
+    $ curl https://api.github.com/organizations
 
-[
-  {
-    "login": "github",
-    "id": 9919,
-    "url": "https://api.github.com/orgs/github",
-    "repos_url": "https://api.github.com/orgs/github/repos",
-    "events_url": "https://api.github.com/orgs/github/events",
-    "members_url": "https://api.github.com/orgs/github/members{/member}",
-    "public_members_url": "https://api.github.com/orgs/github/public_members{/member}",
-    "avatar_url": "https://avatars.githubusercontent.com/u/9919?v=3",
-    "description": "GitHub, the company."
-  },
-  ...
-]
-</pre>
+    [
+      {
+        "login": "github",
+        "id": 9919,
+        "url": "https://api.github.com/orgs/github",
+        "repos_url": "https://api.github.com/orgs/github/repos",
+        "events_url": "https://api.github.com/orgs/github/events",
+        "members_url": "https://api.github.com/orgs/github/members{/member}",
+        "public_members_url": "https://api.github.com/orgs/github/public_members{/member}",
+        "avatar_url": "https://avatars.githubusercontent.com/u/9919?v=3",
+        "description": "GitHub, the company."
+      },
+      ...
+    ]
 
 As always, if you have any questions or feedback, please [drop us a line][contact].
 

--- a/content/changes/2015-08-04-get-license-contents.md
+++ b/content/changes/2015-08-04-get-license-contents.md
@@ -7,14 +7,17 @@ author_name: benbalter
 
 The [License API Preview](/v3/licenses/) now allows you to retrieve the contents of a repository's open source license. As before, when the appropriate preview media type is passed, the repository endpoint will return information about the detected license, if any:
 
+{:.terminal}
     curl -H "Accept: application/vnd.github.drax-preview+json" https://api.github.com/repos/benbalter/gman
 
 You can now also get the contents of the repository's license file, whether or not the license was successfully identified via the license contents endpoint:
 
+{:.terminal}
     curl -H "Accept: application/vnd.github.drax-preview+json" https://api.github.com/repos/benbalter/gman/license
 
 Similar to [the repository contents API](/v3/repos/contents/#get-contents), the license contents method also supports [custom media types](/v3/repos/contents/#custom-media-types) for retrieving the raw license content or rendered license HTML.
 
+{:.terminal}
     curl -H "Accept: application/vnd.github.drax-preview.raw" https://api.github.com/repos/benbalter/gman/license
 
 For more information, see [the license API documentation](/v3/licenses/#get-the-contents-of-a-repositorys-license), and as always, if you have any questions or feedback, please [get in touch with us](https://github.com/contact?form%5Bsubject%5D=License+API).

--- a/content/changes/2015-09-03-ensure-your-app-is-ready-for-protected-branches.md
+++ b/content/changes/2015-09-03-ensure-your-app-is-ready-for-protected-branches.md
@@ -23,16 +23,15 @@ the target commit for all required status checks.
 
 These restrictions are all represented by 422 errors:
 
-<pre class="terminal">
-$ curl -i -H 'Authorization: token TOKEN' \
-    -X DELETE https://api.github.com/repos/octocat/hubot/git/refs/heads/master
-HTTP/1.1 422 Unprocessable Entity
+{:.terminal}
+    $ curl -i -H 'Authorization: token TOKEN' \
+        -X DELETE https://api.github.com/repos/octocat/hubot/git/refs/heads/master
+    HTTP/1.1 422 Unprocessable Entity
 
-{
-  "message": "Cannot delete a protected branch",
-  "documentation_url": "https://help.github.com/articles/about-protected-branches"
-}
-</pre>
+    {
+      "message": "Cannot delete a protected branch",
+      "documentation_url": "https://help.github.com/articles/about-protected-branches"
+    }
 
 Protected branches and required status checks are a great way to ensure your
 project’s conventions are followed. For example, you could write a Status

--- a/content/guides/getting-started.md
+++ b/content/guides/getting-started.md
@@ -22,59 +22,56 @@ There's no easier way to kick the tires than through [cURL][curl].
 Let's start by testing our setup. Open up a command prompt and enter the
 following command (without the `$`):
 
-<pre class="terminal">
-$ curl https://api.github.com/zen
+{:.terminal}
+    $ curl https://api.github.com/zen
 
-Keep it logically awesome.
-</pre>
+    Keep it logically awesome.
 
 The response will be a random selection from our design philosophies.
 
 Next, let's `GET` [Chris Wanstrath's][defunkt github] [GitHub profile][users api]:
 
-<pre class="terminal">
-# GET /users/defunkt
-$ curl https://api.github.com/users/defunkt
+{:.terminal}
+    # GET /users/defunkt
+    $ curl https://api.github.com/users/defunkt
 
-{
-  "login": "defunkt",
-  "id": 2,
-  "url": "https://api.github.com/users/defunkt",
-  "html_url": "https://github.com/defunkt",
-  ...
-}
-</pre>
+    {
+      "login": "defunkt",
+      "id": 2,
+      "url": "https://api.github.com/users/defunkt",
+      "html_url": "https://github.com/defunkt",
+      ...
+    }
 
 Mmmmm, tastes like [JSON][json]. Let's add the `-i` flag to include headers:
 
-<pre class="terminal">
-$ curl -i https://api.github.com/users/defunkt
+{:.terminal}
+    $ curl -i https://api.github.com/users/defunkt
 
-HTTP/1.1 200 OK
-Server: GitHub.com
-Date: Sun, 11 Nov 2012 18:43:28 GMT
-Content-Type: application/json; charset=utf-8
-Connection: keep-alive
-Status: 200 OK
-ETag: "bfd85cbf23ac0b0c8a29bee02e7117c6"
-X-RateLimit-Limit: 60
-X-RateLimit-Remaining: 57
-X-RateLimit-Reset: 1352660008
-X-GitHub-Media-Type: github.v3
-Vary: Accept
-Cache-Control: public, max-age=60, s-maxage=60
-X-Content-Type-Options: nosniff
-Content-Length: 692
-Last-Modified: Tue, 30 Oct 2012 18:58:42 GMT
+    HTTP/1.1 200 OK
+    Server: GitHub.com
+    Date: Sun, 11 Nov 2012 18:43:28 GMT
+    Content-Type: application/json; charset=utf-8
+    Connection: keep-alive
+    Status: 200 OK
+    ETag: "bfd85cbf23ac0b0c8a29bee02e7117c6"
+    X-RateLimit-Limit: 60
+    X-RateLimit-Remaining: 57
+    X-RateLimit-Reset: 1352660008
+    X-GitHub-Media-Type: github.v3
+    Vary: Accept
+    Cache-Control: public, max-age=60, s-maxage=60
+    X-Content-Type-Options: nosniff
+    Content-Length: 692
+    Last-Modified: Tue, 30 Oct 2012 18:58:42 GMT
 
-{
-  "login": "defunkt",
-  "id": 2,
-  "url": "https://api.github.com/users/defunkt",
-  "html_url": "https://github.com/defunkt",
-  ...
-}
-</pre>
+    {
+      "login": "defunkt",
+      "id": 2,
+      "url": "https://api.github.com/users/defunkt",
+      "html_url": "https://github.com/defunkt",
+      ...
+    }
 
 There are a few interesting bits in the response headers. As expected, the
 `Content-Type` is `application/json`.
@@ -101,11 +98,10 @@ _authenticate_. In fact, doing anything interesting with the GitHub API requires
 The easiest way to authenticate with the GitHub API is by simply using your GitHub
 username and password via Basic Authentication.
 
-<pre class="terminal">
-$ curl -i -u &lt;your_username&gt; https://api.github.com/users/defunkt
+{:.terminal}
+    $ curl -i -u <your_username> https://api.github.com/users/defunkt
 
-Enter host password for user '&lt;your_username&gt;':
-</pre>
+    Enter host password for user '<your_username>':
 
 The `-u` flag sets the username, and cURL will prompt you for the password. You
 can use `-u "username:password"` to avoid the prompt, but this leaves your
@@ -121,19 +117,18 @@ reading and writing private information via the API.
 If you have [two-factor authentication][2fa] enabled, the API will return a
 `401 Unauthorized` error code for the above request (and every other API request):
 
-<pre class="terminal">
-$ curl -i -u &lt;your_username&gt; https://api.github.com/users/defunkt
+{:.terminal}
+    $ curl -i -u <your_username> https://api.github.com/users/defunkt
 
-Enter host password for user '&lt;your_username&gt;':
+    Enter host password for user '<your_username>':
 
-HTTP/1.1 401 Unauthorized
-X-GitHub-OTP: required; :2fa-type
+    HTTP/1.1 401 Unauthorized
+    X-GitHub-OTP: required; :2fa-type
 
-{
-  "message": "Must specify two-factor authentication OTP code.",
-  "documentation_url": "https://developer.github.com/v3/auth#working-with-two-factor-authentication"
-}
-</pre>
+    {
+      "message": "Must specify two-factor authentication OTP code.",
+      "documentation_url": "https://developer.github.com/v3/auth#working-with-two-factor-authentication"
+    }
 
 The easiest way to get around that error is to create an OAuth token and use
 OAuth authentication instead of Basic Authentication. See the
@@ -145,20 +140,19 @@ When properly authenticated, you can take advantage of the permissions
 associated with your GitHub account. For example, try getting
 [your own user profile][auth user api]:
 
-<pre class="terminal">
-$ curl -i -u &lt;your_username&gt; https://api.github.com/user
+{:.terminal}
+    $ curl -i -u <your_username> https://api.github.com/user
 
-{
-  ...
-  "plan": {
-    "space": 2516582,
-    "collaborators": 10,
-    "private_repos": 20,
-    "name": "medium"
-  }
-  ...
-}
-</pre>
+    {
+      ...
+      "plan": {
+        "space": 2516582,
+        "collaborators": 10,
+        "private_repos": 20,
+        "name": "medium"
+      }
+      ...
+    }
 
 This time, in addition to the same set of public information we
 retrieved for [@defunkt][defunkt github] earlier, you should also see the non-public
@@ -195,32 +189,31 @@ An easier way to get a token is to [create a **personal access token**][personal
 Also, the [**Authorizations API**][authorizations api] makes it simple to use Basic Authentication
 to create an OAuth token. Try pasting and running the following command:
 
-<pre class="terminal">
-$ curl -i -u &lt;your_username&gt; -d '{"scopes": ["repo", "user"], "note": "getting-started"}' \
-    https://api.github.com/authorizations
+{:.terminal}
+    $ curl -i -u <your_username> -d '{"scopes": ["repo", "user"], "note": "getting-started"}' \
+        https://api.github.com/authorizations
 
-HTTP/1.1 201 Created
-Location: https://api.github.com/authorizations/2
-Content-Length: 384
+    HTTP/1.1 201 Created
+    Location: https://api.github.com/authorizations/2
+    Content-Length: 384
 
-{
-  "scopes": [
-    "repo",
-    "user"
-  ],
-  "token": "5199831f4dd3b79e7c5b7e0ebe75d67aa66e79d4",
-  "updated_at": "2012-11-14T14:04:24Z",
-  "url": "https://api.github.com/authorizations/2",
-  "app": {
-    "url": "https://developer.github.com/v3/oauth/#oauth-authorizations-api",
-    "name": "GitHub API"
-  },
-  "created_at": "2012-11-14T14:04:24Z",
-  "note_url": null,
-  "id": 2,
-  "note": "getting-started"
-}
-</pre>
+    {
+      "scopes": [
+        "repo",
+        "user"
+      ],
+      "token": "5199831f4dd3b79e7c5b7e0ebe75d67aa66e79d4",
+      "updated_at": "2012-11-14T14:04:24Z",
+      "url": "https://api.github.com/authorizations/2",
+      "app": {
+        "url": "https://developer.github.com/v3/oauth/#oauth-authorizations-api",
+        "name": "GitHub API"
+      },
+      "created_at": "2012-11-14T14:04:24Z",
+      "note_url": null,
+      "id": 2,
+      "note": "getting-started"
+    }
 
 There's a lot going on in this one little call, so let's break it down. First,
 the `-d` flag indicates we're doing a `POST`, using the
@@ -244,11 +237,10 @@ return the [previously described `401 Unauthorized` error code][2fa section]
 for the above request. You can get around that error by providing a 2FA OTP code
 in the [X-GitHub-OTP request header][2fa header]:
 
-<pre class="terminal">
-$ curl -i -u &lt;your_username&gt; -H "X-GitHub-OTP: &lt;your_2fa_OTP_code&gt;" \
-    -d '{"scopes": ["repo", "user"], "note": "getting-started"}' \
-    https://api.github.com/authorizations
-</pre>
+{:.terminal}
+    $ curl -i -u <your_username> -H "X-GitHub-OTP: <your_2fa_OTP_code>" \
+        -d '{"scopes": ["repo", "user"], "note": "getting-started"}' \
+        https://api.github.com/authorizations
 
 If you enabled 2FA with a mobile application, go ahead and get an OTP code from
 your one-time password application on your phone. If you enabled 2FA with text
@@ -258,10 +250,9 @@ this endpoint.
 Now, we can use the forty character `token` instead of a username and password
 in the rest of our examples. Let's grab our own user info again, using OAuth this time:
 
-<pre class="terminal">
-$ curl -i -H 'Authorization: token 5199831f4dd3b79e7c5b7e0ebe75d67aa66e79d4' \
-    https://api.github.com/user
-</pre>
+{:.terminal}
+    $ curl -i -H 'Authorization: token 5199831f4dd3b79e7c5b7e0ebe75d67aa66e79d4' \
+        https://api.github.com/user
 
 **Treat OAuth tokens like passwords!** Don't share them with other users or store
 them in insecure places. The tokens in these examples are fake and the names have
@@ -276,28 +267,24 @@ Almost any meaningful use of the GitHub API will involve some level of Repositor
 information. We can [`GET` repository details][get repo] in the same way we fetched user
 details earlier:
 
-<pre class="terminal">
-$ curl -i https://api.github.com/repos/twbs/bootstrap
-</pre>
+{:.terminal}
+    $ curl -i https://api.github.com/repos/twbs/bootstrap
 
 In the same way, we can [view repositories for the authenticated user][user repos api]:
 
-<pre class="terminal">
-$ curl -i -H 'Authorization: token 5199831f4dd3b79e7c5b7e0ebe75d67aa66e79d4' \
-    https://api.github.com/user/repos
-</pre>
+{:.terminal}
+    $ curl -i -H 'Authorization: token 5199831f4dd3b79e7c5b7e0ebe75d67aa66e79d4' \
+        https://api.github.com/user/repos
 
 Or, we can [list repositories for another user][other user repos api]:
 
-<pre class="terminal">
-$ curl -i https://api.github.com/users/technoweenie/repos
-</pre>
+{:.terminal}
+    $ curl -i https://api.github.com/users/technoweenie/repos
 
 Or, we can [list repositories for an organization][org repos api]:
 
-<pre class="terminal">
-$ curl -i https://api.github.com/orgs/mozilla/repos
-</pre>
+{:.terminal}
+    $ curl -i https://api.github.com/orgs/mozilla/repos
 
 The information returned from these calls will depend on how we authenticate:
 
@@ -311,9 +298,8 @@ can filter the repositories returned based on what type of access the user has
 for the repository. In this way, we can fetch only directly-owned repositories,
 organization repositories, or repositories the user collaborates on via a team.
 
-<pre class="terminal">
-$ curl -i "https://api.github.com/users/technoweenie/repos?type=owner"
-</pre>
+{:.terminal}
+    $ curl -i "https://api.github.com/users/technoweenie/repos?type=owner"
 
 In this example, we grab only those repositories that technoweenie owns, not the
 ones on which he collaborates. Note the quoted URL above. Depending on your
@@ -326,16 +312,15 @@ Fetching information for existing repositories is a common use case, but the
 GitHub API supports creating new repositories as well. To [create a repository][create repo],
 we need to `POST` some JSON containing the details and configuration options.
 
-<pre class="terminal">
-$ curl -i -H 'Authorization: token 5199831f4dd3b79e7c5b7e0ebe75d67aa66e79d4' \
-    -d '{ \
-        "name": "blog", \
-        "auto_init": true, \
-        "private": true, \
-        "gitignore_template": "nanoc" \
-      }' \
-    https://api.github.com/user/repos
-</pre>
+{:.terminal}
+    $ curl -i -H 'Authorization: token 5199831f4dd3b79e7c5b7e0ebe75d67aa66e79d4' \
+        -d '{ \
+            "name": "blog", \
+            "auto_init": true, \
+            "private": true, \
+            "gitignore_template": "nanoc" \
+          }' \
+        https://api.github.com/user/repos
 
 In this minimal example, we create a new repository for our blog (to be served
 on [GitHub Pages][pages], perhaps). Though the blog will be public, we've made
@@ -349,15 +334,14 @@ an owner, just change the API method from `/user/repos` to `/orgs/<org_name>/rep
 
 Next, let's fetch our newly created repository:
 
-<pre class="terminal">
-$ curl -i https://api.github.com/repos/pengwynn/blog
+{:.terminal}
+    $ curl -i https://api.github.com/repos/pengwynn/blog
 
-HTTP/1.1 404 Not Found
+    HTTP/1.1 404 Not Found
 
-{
-    "message": "Not Found"
-}
-</pre>
+    {
+        "message": "Not Found"
+    }
 
 Oh noes! Where did it go? Since we created the repository as _private_, we need
 to authenticate in order to see it. If you're a grizzled HTTP user, you might
@@ -375,24 +359,21 @@ your team.
 Just like github.com, the API provides a few methods to view issues for the
 authenticated user. To [see all your issues][get issues api], call `GET /issues`:
 
-<pre class="terminal">
-$ curl -i -H 'Authorization: token 5199831f4dd3b79e7c5b7e0ebe75d67aa66e79d4' \
-    https://api.github.com/issues
-</pre>
+{:.terminal}
+    $ curl -i -H 'Authorization: token 5199831f4dd3b79e7c5b7e0ebe75d67aa66e79d4' \
+        https://api.github.com/issues
 
 To get only the [issues under one of your GitHub organizations][get issues api], call `GET
 /orgs/<org>/issues`:
 
-<pre class="terminal">
-$ curl -i -H 'Authorization: token 5199831f4dd3b79e7c5b7e0ebe75d67aa66e79d4' \
-    https://api.github.com/orgs/rails/issues
-</pre>
+{:.terminal}
+    $ curl -i -H 'Authorization: token 5199831f4dd3b79e7c5b7e0ebe75d67aa66e79d4' \
+        https://api.github.com/orgs/rails/issues
 
 We can also get [all the issues under a single repository][repo issues api]:
 
-<pre class="terminal">
-$ curl -i https://api.github.com/repos/rails/rails/issues
-</pre>
+{:.terminal}
+    $ curl -i https://api.github.com/repos/rails/rails/issues
 
 ### Pagination
 
@@ -400,14 +381,13 @@ A project the size of Rails has thousands of issues. We'll need to [paginate][pa
 making multiple API calls to get the data. Let's repeat that last call, this
 time taking note of the response headers:
 
-<pre class="terminal">
-$ curl -i https://api.github.com/repos/rails/rails/issues
+{:.terminal}
+    $ curl -i https://api.github.com/repos/rails/rails/issues
 
-HTTP/1.1 200 OK
+    HTTP/1.1 200 OK
 
-Link: &lt;https://api.github.com/repos/rails/rails/issues?page=2&gt;; rel="next",
-&lt;https://api.github.com/repos/rails/rails/issues?page=14&gt;; rel="last"
-</pre>
+    Link: <https://api.github.com/repos/rails/rails/issues?page=2>; rel="next",
+    <https://api.github.com/repos/rails/rails/issues?page=14>; rel="last"
 
 The [`Link` header][link-header] provides a way for a response to link to
 external resources, in this case additional pages of data. Since our call found
@@ -424,55 +404,54 @@ OAuth token in the header. Also, we'll pass the title, body, and labels in the J
 body to the `/issues` path underneath the repository in which we want to create
 the issue:
 
-<pre class="terminal">
-$ curl -i -H 'Authorization: token 5199831f4dd3b79e7c5b7e0ebe75d67aa66e79d4' \
-    -d '{ \
-         "title": "New logo", \
-         "body": "We should have one", \
-         "labels": ["design"] \
-       }' \
-    https://api.github.com/repos/pengwynn/api-sandbox/issues
+{:.terminal}
+    $ curl -i -H 'Authorization: token 5199831f4dd3b79e7c5b7e0ebe75d67aa66e79d4' \
+        -d '{ \
+             "title": "New logo", \
+             "body": "We should have one", \
+             "labels": ["design"] \
+           }' \
+        https://api.github.com/repos/pengwynn/api-sandbox/issues
 
-HTTP/1.1 201 Created
-Location: https://api.github.com/repos/pengwynn/api-sandbox/issues/17
-X-RateLimit-Limit: 5000
+    HTTP/1.1 201 Created
+    Location: https://api.github.com/repos/pengwynn/api-sandbox/issues/17
+    X-RateLimit-Limit: 5000
 
-{
-  "pull_request": {
-    "patch_url": null,
-    "html_url": null,
-    "diff_url": null
-  },
-  "created_at": "2012-11-14T15:25:33Z",
-  "comments": 0,
-  "milestone": null,
-  "title": "New logo",
-  "body": "We should have one",
-  "user": {
-    "login": "pengwynn",
-    "gravatar_id": "7e19cd5486b5d6dc1ef90e671ba52ae0",
-    "avatar_url": "https://secure.gravatar.com/avatar/7e19cd5486b5d6dc1ef90e671ba52ae0?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png",
-    "id": 865,
-    "url": "https://api.github.com/users/pengwynn"
-  },
-  "closed_at": null,
-  "updated_at": "2012-11-14T15:25:33Z",
-  "number": 17,
-  "closed_by": null,
-  "html_url": "https://github.com/pengwynn/api-sandbox/issues/17",
-  "labels": [
     {
-      "color": "ededed",
-      "name": "design",
-      "url": "https://api.github.com/repos/pengwynn/api-sandbox/labels/design"
+      "pull_request": {
+        "patch_url": null,
+        "html_url": null,
+        "diff_url": null
+      },
+      "created_at": "2012-11-14T15:25:33Z",
+      "comments": 0,
+      "milestone": null,
+      "title": "New logo",
+      "body": "We should have one",
+      "user": {
+        "login": "pengwynn",
+        "gravatar_id": "7e19cd5486b5d6dc1ef90e671ba52ae0",
+        "avatar_url": "https://secure.gravatar.com/avatar/7e19cd5486b5d6dc1ef90e671ba52ae0?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png",
+        "id": 865,
+        "url": "https://api.github.com/users/pengwynn"
+      },
+      "closed_at": null,
+      "updated_at": "2012-11-14T15:25:33Z",
+      "number": 17,
+      "closed_by": null,
+      "html_url": "https://github.com/pengwynn/api-sandbox/issues/17",
+      "labels": [
+        {
+          "color": "ededed",
+          "name": "design",
+          "url": "https://api.github.com/repos/pengwynn/api-sandbox/labels/design"
+        }
+      ],
+      "id": 8356941,
+      "assignee": null,
+      "state": "open",
+      "url": "https://api.github.com/repos/pengwynn/api-sandbox/issues/17"
     }
-  ],
-  "id": 8356941,
-  "assignee": null,
-  "state": "open",
-  "url": "https://api.github.com/repos/pengwynn/api-sandbox/issues/17"
-}
-</pre>
 
 The response gives us a couple of pointers to the newly created issue, both in
 the `Location` response header and the `url` field of the JSON response.
@@ -484,24 +463,22 @@ caching information that hasn't changed. The API supports [conditional
 requests][conditional-requests] and helps you do the right thing. Consider the
 first call we made to get defunkt's profile:
 
-<pre class="terminal">
-$ curl -i https://api.github.com/users/defunkt
+{:.terminal}
+    $ curl -i https://api.github.com/users/defunkt
 
-HTTP/1.1 200 OK
-ETag: "bfd85cbf23ac0b0c8a29bee02e7117c6"
-</pre>
+    HTTP/1.1 200 OK
+    ETag: "bfd85cbf23ac0b0c8a29bee02e7117c6"
 
 In addition to the JSON body, take note of the HTTP status code of `200` and
 the `ETag` header.
 The [ETag][etag] is a fingerprint of the response. If we pass that on subsequent calls,
 we can tell the API to give us the resource again, only if it has changed:
 
-<pre class="terminal">
-$ curl -i -H 'If-None-Match: "bfd85cbf23ac0b0c8a29bee02e7117c6"' \
-    https://api.github.com/users/defunkt
+{:.terminal}
+    $ curl -i -H 'If-None-Match: "bfd85cbf23ac0b0c8a29bee02e7117c6"' \
+        https://api.github.com/users/defunkt
 
-HTTP/1.1 304 Not Modified
-</pre>
+    HTTP/1.1 304 Not Modified
 
 The `304` status indicates that the resource hasn't changed since the last time
 we asked for it and the response will contain no body. As a bonus, `304`

--- a/content/guides/traversing-with-pagination.md
+++ b/content/guides/traversing-with-pagination.md
@@ -32,6 +32,7 @@ Information about pagination is provided in [the Link header](http://tools.ietf.
 of an API call. For example, let's make a curl request to the search API, to find
 out how many times Mozilla projects use the phrase `addClass`:
 
+{:.terminal}
     curl -I "https://api.github.com/search/code?q=addClass+user:mozilla"
 
 The `-I` parameter indicates that we only care about the headers, not the actual
@@ -59,6 +60,7 @@ through the pages to consume the results. You do this by passing in a `page`
 parameter. By default, `page` always starts at `1`. Let's jump ahead to page 14
 and see what happens:
 
+{:.terminal}
     curl -I "https://api.github.com/search/code?q=addClass+user:mozilla&page=14"
 
 Here's the link header once more:
@@ -79,6 +81,7 @@ between the first, previous, next, or last list of results in an API call.
 By passing the `per_page` parameter, you can specify how many items you want
 each page to return, up to 100 items. Let's try asking for 50 items about `addClass`:
 
+{:.terminal}
     curl -I "https://api.github.com/search/code?q=addClass+user:mozilla&per_page=50"
 
 Notice what it does to the header response:

--- a/content/guides/using-ssh-agent-forwarding.md
+++ b/content/guides/using-ssh-agent-forwarding.md
@@ -130,9 +130,8 @@ $ echo "$SSH_AUTH_SOCK"
 
 You can check that your key is visible to `ssh-agent` by running the following command:
 
-<pre class="terminal">
-ssh-add -L
-</pre>
+{:.terminal}
+    ssh-add -L
 
 If the command says that no identity is available, you'll need to add your key:
 

--- a/content/v3.md
+++ b/content/v3.md
@@ -23,26 +23,25 @@ All API access is over HTTPS, and accessed from the `api.github.com`
 domain (or through `yourdomain.com/api/v3/` for enterprise).  All data is
 sent and received as JSON.
 
-<pre class="terminal">
-$ curl -i https://api.github.com/users/octocat/orgs
+{:.terminal}
+    $ curl -i https://api.github.com/users/octocat/orgs
 
-HTTP/1.1 200 OK
-Server: nginx
-Date: Fri, 12 Oct 2012 23:33:14 GMT
-Content-Type: application/json; charset=utf-8
-Connection: keep-alive
-Status: 200 OK
-ETag: "a00049ba79152d03380c34652f2cb612"
-X-GitHub-Media-Type: github.v3
-X-RateLimit-Limit: 5000
-X-RateLimit-Remaining: 4987
-X-RateLimit-Reset: 1350085394
-Content-Length: 5
-Cache-Control: max-age=0, private, must-revalidate
-X-Content-Type-Options: nosniff
+    HTTP/1.1 200 OK
+    Server: nginx
+    Date: Fri, 12 Oct 2012 23:33:14 GMT
+    Content-Type: application/json; charset=utf-8
+    Connection: keep-alive
+    Status: 200 OK
+    ETag: "a00049ba79152d03380c34652f2cb612"
+    X-GitHub-Media-Type: github.v3
+    X-RateLimit-Limit: 5000
+    X-RateLimit-Remaining: 4987
+    X-RateLimit-Reset: 1350085394
+    Content-Length: 5
+    Cache-Control: max-age=0, private, must-revalidate
+    X-Content-Type-Options: nosniff
 
-[]
-</pre>
+    []
 
 Blank fields are included as `null` instead of being omitted.
 
@@ -86,9 +85,8 @@ Many API methods take optional parameters. For GET requests, any parameters not
 specified as a segment in the path can be passed as an HTTP query string
 parameter:
 
-<pre class="terminal">
-$ curl -i "https://api.github.com/repos/vmg/redcarpet/issues?state=closed"
-</pre>
+{:.terminal}
+    $ curl -i "https://api.github.com/repos/vmg/redcarpet/issues?state=closed"
 
 In this example, the 'vmg' and 'redcarpet' values are provided for the `:owner`
 and `:repo` parameters in the path while `:state` is passed in the query
@@ -97,17 +95,15 @@ string.
 For POST, PATCH, PUT, and DELETE requests, parameters not included in the URL should be encoded as JSON
 with a Content-Type of 'application/json':
 
-<pre class="terminal">
-$ curl -i -u username -d '{"scopes":["public_repo"]}' https://api.github.com/authorizations
-</pre>
+{:.terminal}
+    $ curl -i -u username -d '{"scopes":["public_repo"]}' https://api.github.com/authorizations
 
 ## Root Endpoint
 
 You can issue a `GET` request to the root endpoint to get all the endpoint categories that the API supports:
 
-<pre class="terminal">
-$ curl https://api.github.com
-</pre>
+{:.terminal}
+    $ curl https://api.github.com
 
 Note that for GitHub Enterprise, [as with all other endpoints](https://developer.github.com/v3/enterprise/#endpoint-urls), you'll need to pass in your GitHub Enterprise endpoint as the hostname, *as well as your username and password*:
 
@@ -205,21 +201,18 @@ of private repositories to unauthorized users.
 
 ### Basic Authentication
 
-<pre class="terminal">
-$ curl -u "username" https://api.github.com
-</pre>
+{:.terminal}
+    $ curl -u "username" https://api.github.com
 
 ### OAuth2 Token (sent in a header)
 
-<pre class="terminal">
-$ curl -H "Authorization: token OAUTH-TOKEN" https://api.github.com
-</pre>
+{:.terminal}
+    $ curl -H "Authorization: token OAUTH-TOKEN" https://api.github.com
 
 ### OAuth2 Token (sent as a parameter)
 
-<pre class="terminal">
-$ curl https://api.github.com/?access_token=OAUTH-TOKEN
-</pre>
+{:.terminal}
+    $ curl https://api.github.com/?access_token=OAUTH-TOKEN
 
 Read [more about OAuth2](/v3/oauth/).  Note that OAuth2 tokens can be [acquired
 programmatically](/v3/oauth_authorizations/#create-a-new-authorization), for applications that
@@ -227,9 +220,8 @@ are not websites.
 
 ### OAuth2 Key/Secret
 
-<pre class="terminal">
-$ curl 'https://api.github.com/users/whatever?client_id=xxxx&client_secret=yyyy'
-</pre>
+{:.terminal}
+    $ curl 'https://api.github.com/users/whatever?client_id=xxxx&client_secret=yyyy'
 
 This should only be used in server to server scenarios.  Don't leak your
 OAuth application's client secret to your users.  Read [more about
@@ -239,31 +231,29 @@ unauthenticated rate limiting](#increasing-the-unauthenticated-rate-limit-for-oa
 
 Authenticating with invalid credentials will return `401 Unauthorized`:
 
-<pre class="terminal">
-$ curl -i https://api.github.com -u foo:bar
+{:.terminal}
+    $ curl -i https://api.github.com -u foo:bar
 
-HTTP/1.1 401 Unauthorized
+    HTTP/1.1 401 Unauthorized
 
-{
-  "message": "Bad credentials",
-  "documentation_url": "https://developer.github.com/v3"
-}
-</pre>
+    {
+      "message": "Bad credentials",
+      "documentation_url": "https://developer.github.com/v3"
+    }
 
 After detecting several requests with invalid credentials within a short period,
 the API will temporarily reject all authentication attempts for that user
 (including ones with valid credentials) with `403 Forbidden`:
 
-<pre class="terminal">
-$ curl -i https://api.github.com -u valid_username:valid_password
+{:.terminal}
+    $ curl -i https://api.github.com -u valid_username:valid_password
 
-HTTP/1.1 403 Forbidden
+    HTTP/1.1 403 Forbidden
 
-{
-  "message": "Maximum number of login attempts exceeded. Please try again later.",
-  "documentation_url": "https://developer.github.com/v3"
-}
-</pre>
+    {
+      "message": "Maximum number of login attempts exceeded. Please try again later.",
+      "documentation_url": "https://developer.github.com/v3"
+    }
 
 ## Hypermedia
 
@@ -297,9 +287,8 @@ resources, you can also set a custom page size up to 100 with the `?per_page` pa
 Note that for technical reasons not all endpoints respect the `?per_page` parameter,
 see [events](https://developer.github.com/v3/activity/events/) for example.
 
-<pre class="terminal">
-$ curl 'https://api.github.com/user/repos?page=2&per_page=100'
-</pre>
+{:.terminal}
+    $ curl 'https://api.github.com/user/repos?page=2&per_page=100'
 
 Note that page numbering is 1-based and that omitting the `?page`
 parameter will return the first page.
@@ -342,16 +331,15 @@ rules](/v3/search/#rate-limit).
 You can check the returned HTTP headers of any API request to see your current
 rate limit status:
 
-<pre class="terminal">
-$ curl -i https://api.github.com/users/whatever
+{:.terminal}
+    $ curl -i https://api.github.com/users/whatever
 
-HTTP/1.1 200 OK
-Date: Mon, 01 Jul 2013 17:27:06 GMT
-Status: 200 OK
-X-RateLimit-Limit: 60
-X-RateLimit-Remaining: 56
-X-RateLimit-Reset: 1372700873
-</pre>
+    HTTP/1.1 200 OK
+    Date: Mon, 01 Jul 2013 17:27:06 GMT
+    Status: 200 OK
+    X-RateLimit-Limit: 60
+    X-RateLimit-Remaining: 56
+    X-RateLimit-Reset: 1372700873
 
 The headers tell you everything you need to know about your current rate limit status:
 
@@ -370,19 +358,18 @@ new Date(1372700873 * 1000)
 
 Once you go over the rate limit you will receive an error response:
 
-<pre class="terminal">
-HTTP/1.1 403 Forbidden
-Date: Tue, 20 Aug 2013 14:50:41 GMT
-Status: 403 Forbidden
-X-RateLimit-Limit: 60
-X-RateLimit-Remaining: 0
-X-RateLimit-Reset: 1377013266
+{:.terminal}
+    HTTP/1.1 403 Forbidden
+    Date: Tue, 20 Aug 2013 14:50:41 GMT
+    Status: 403 Forbidden
+    X-RateLimit-Limit: 60
+    X-RateLimit-Remaining: 0
+    X-RateLimit-Reset: 1377013266
 
-{
-    "message": "API rate limit exceeded for xxx.xxx.xxx.xxx. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)",
-    "documentation_url": "https://developer.github.com/v3/#rate-limiting"
-}
-</pre>
+    {
+        "message": "API rate limit exceeded for xxx.xxx.xxx.xxx. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)",
+        "documentation_url": "https://developer.github.com/v3/#rate-limiting"
+    }
 
 You can also [check your rate limit status](/v3/rate_limit) without incurring an
 API hit.
@@ -392,16 +379,15 @@ API hit.
 
 If your OAuth application needs to make unauthenticated calls with a higher rate limit, you can pass your app's client ID and secret as part of the query string.
 
-<pre class="terminal">
-$ curl -i 'https://api.github.com/users/whatever?client_id=xxxx&client_secret=yyyy'
+{:.terminal}
+    $ curl -i 'https://api.github.com/users/whatever?client_id=xxxx&client_secret=yyyy'
 
-HTTP/1.1 200 OK
-Date: Mon, 01 Jul 2013 17:27:06 GMT
-Status: 200 OK
-X-RateLimit-Limit: 5000
-X-RateLimit-Remaining: 4966
-X-RateLimit-Reset: 1372700873
-</pre>
+    HTTP/1.1 200 OK
+    Date: Mon, 01 Jul 2013 17:27:06 GMT
+    Status: 200 OK
+    X-RateLimit-Limit: 5000
+    X-RateLimit-Remaining: 4966
+    X-RateLimit-Reset: 1372700873
 
 This method should only be used for server-to-server calls. You should never
 share your client secret with anyone or include it in client-side browser code.
@@ -432,16 +418,15 @@ this rate limit. To ensure you're acting as a good API citizen, check out our
 If your application triggers this rate limit, you'll receive an informative
 response:
 
-<pre class="terminal">
-HTTP/1.1 403 Forbidden
-Content-Type: application/json; charset=utf-8
-Connection: close
+{:.terminal}
+    HTTP/1.1 403 Forbidden
+    Content-Type: application/json; charset=utf-8
+    Connection: close
 
-{
-  "message": "You have triggered an abuse detection mechanism and have been temporarily blocked from content creation. Please retry your request again later.",
-  "documentation_url": "https://developer.github.com/v3#abuse-rate-limits"
-}
-</pre>
+    {
+      "message": "You have triggered an abuse detection mechanism and have been temporarily blocked from content creation. Please retry your request again later.",
+      "documentation_url": "https://developer.github.com/v3#abuse-rate-limits"
+    }
 
 ## User Agent Required
 
@@ -451,22 +436,20 @@ application, for the `User-Agent` header value. This allows us to contact you if
 
 Here's an example:
 
-<pre class="terminal">
-User-Agent: Awesome-Octocat-App
-</pre>
+{:.terminal}
+    User-Agent: Awesome-Octocat-App
 
 If you provide an invalid `User-Agent` header, you will receive a `403 Forbidden` response:
 
-<pre class="terminal">
-$ curl -iH 'User-Agent: ' https://api.github.com/meta
-HTTP/1.0 403 Forbidden
-Connection: close
-Content-Type: text/html
+{:.terminal}
+    $ curl -iH 'User-Agent: ' https://api.github.com/meta
+    HTTP/1.0 403 Forbidden
+    Connection: close
+    Content-Type: text/html
 
-Request forbidden by administrative rules.
-Please make sure your request has a User-Agent header.
-Check https://developer.github.com for other possible causes.
-</pre>
+    Request forbidden by administrative rules.
+    Please make sure your request has a User-Agent header.
+    Check https://developer.github.com for other possible causes.
 
 ## Conditional requests
 
@@ -477,39 +460,38 @@ has not changed, the server will return a `304 Not Modified`. Also note: making
 a conditional request and receiving a 304 response does not count against your
 [Rate Limit](#rate-limiting), so we encourage you to use it whenever possible.
 
-<pre class="terminal">
-$ curl -i https://api.github.com/user
-HTTP/1.1 200 OK
-Cache-Control: private, max-age=60
-ETag: "644b5b0155e6404a9cc4bd9d8b1ae730"
-Last-Modified: Thu, 05 Jul 2012 15:31:30 GMT
-Status: 200 OK
-Vary: Accept, Authorization, Cookie
-X-RateLimit-Limit: 5000
-X-RateLimit-Remaining: 4996
-X-RateLimit-Reset: 1372700873
+{:.terminal}
+    $ curl -i https://api.github.com/user
+    HTTP/1.1 200 OK
+    Cache-Control: private, max-age=60
+    ETag: "644b5b0155e6404a9cc4bd9d8b1ae730"
+    Last-Modified: Thu, 05 Jul 2012 15:31:30 GMT
+    Status: 200 OK
+    Vary: Accept, Authorization, Cookie
+    X-RateLimit-Limit: 5000
+    X-RateLimit-Remaining: 4996
+    X-RateLimit-Reset: 1372700873
 
-$ curl -i https://api.github.com/user -H 'If-None-Match: "644b5b0155e6404a9cc4bd9d8b1ae730"'
-HTTP/1.1 304 Not Modified
-Cache-Control: private, max-age=60
-ETag: "644b5b0155e6404a9cc4bd9d8b1ae730"
-Last-Modified: Thu, 05 Jul 2012 15:31:30 GMT
-Status: 304 Not Modified
-Vary: Accept, Authorization, Cookie
-X-RateLimit-Limit: 5000
-X-RateLimit-Remaining: 4996
-X-RateLimit-Reset: 1372700873
+    $ curl -i https://api.github.com/user -H 'If-None-Match: "644b5b0155e6404a9cc4bd9d8b1ae730"'
+    HTTP/1.1 304 Not Modified
+    Cache-Control: private, max-age=60
+    ETag: "644b5b0155e6404a9cc4bd9d8b1ae730"
+    Last-Modified: Thu, 05 Jul 2012 15:31:30 GMT
+    Status: 304 Not Modified
+    Vary: Accept, Authorization, Cookie
+    X-RateLimit-Limit: 5000
+    X-RateLimit-Remaining: 4996
+    X-RateLimit-Reset: 1372700873
 
-$ curl -i https://api.github.com/user -H "If-Modified-Since: Thu, 05 Jul 2012 15:31:30 GMT"
-HTTP/1.1 304 Not Modified
-Cache-Control: private, max-age=60
-Last-Modified: Thu, 05 Jul 2012 15:31:30 GMT
-Status: 304 Not Modified
-Vary: Accept, Authorization, Cookie
-X-RateLimit-Limit: 5000
-X-RateLimit-Remaining: 4996
-X-RateLimit-Reset: 1372700873
-</pre>
+    $ curl -i https://api.github.com/user -H "If-Modified-Since: Thu, 05 Jul 2012 15:31:30 GMT"
+    HTTP/1.1 304 Not Modified
+    Cache-Control: private, max-age=60
+    Last-Modified: Thu, 05 Jul 2012 15:31:30 GMT
+    Status: 304 Not Modified
+    Vary: Accept, Authorization, Cookie
+    X-RateLimit-Limit: 5000
+    X-RateLimit-Remaining: 4996
+    X-RateLimit-Reset: 1372700873
 
 ## Cross Origin Resource Sharing
 
@@ -522,26 +504,24 @@ HTML 5 Security Guide.
 Here's a sample request sent from a browser hitting
 `http://example.com`:
 
-<pre class="terminal">
-$ curl -i https://api.github.com -H "Origin: http://example.com"
-HTTP/1.1 302 Found
-Access-Control-Allow-Origin: *
-Access-Control-Expose-Headers: ETag, Link, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval
-Access-Control-Allow-Credentials: true
-</pre>
+{:.terminal}
+    $ curl -i https://api.github.com -H "Origin: http://example.com"
+    HTTP/1.1 302 Found
+    Access-Control-Allow-Origin: *
+    Access-Control-Expose-Headers: ETag, Link, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval
+    Access-Control-Allow-Credentials: true
 
 This is what the CORS preflight request looks like:
 
-<pre class="terminal">
-$ curl -i https://api.github.com -H "Origin: http://example.com" -X OPTIONS
-HTTP/1.1 204 No Content
-Access-Control-Allow-Origin: *
-Access-Control-Allow-Headers: Authorization, Content-Type, If-Match, If-Modified-Since, If-None-Match, If-Unmodified-Since, X-GitHub-OTP, X-Requested-With
-Access-Control-Allow-Methods: GET, POST, PATCH, PUT, DELETE
-Access-Control-Expose-Headers: ETag, Link, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval
-Access-Control-Max-Age: 86400
-Access-Control-Allow-Credentials: true
-</pre>
+{:.terminal}
+    $ curl -i https://api.github.com -H "Origin: http://example.com" -X OPTIONS
+    HTTP/1.1 204 No Content
+    Access-Control-Allow-Origin: *
+    Access-Control-Allow-Headers: Authorization, Content-Type, If-Match, If-Modified-Since, If-None-Match, If-Unmodified-Since, X-GitHub-OTP, X-Requested-With
+    Access-Control-Allow-Methods: GET, POST, PATCH, PUT, DELETE
+    Access-Control-Expose-Headers: ETag, Link, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval
+    Access-Control-Max-Age: 86400
+    Access-Control-Allow-Credentials: true
 
 ## JSON-P Callbacks
 
@@ -551,24 +531,23 @@ to embed GitHub content in web pages by getting around cross domain
 issues.  The response includes the same data output as the regular API,
 plus the relevant HTTP Header information.
 
-<pre class="terminal">
-$ curl https://api.github.com?callback=foo
+{:.terminal}
+    $ curl https://api.github.com?callback=foo
 
-/**/foo({
-  "meta": {
-    "status": 200,
-    "X-RateLimit-Limit": "5000",
-    "X-RateLimit-Remaining": "4966",
-    "X-RateLimit-Reset": "1372700873",
-    "Link": [ // pagination headers and other links
-      ["https://api.github.com?page=2", {"rel": "next"}]
-    ]
-  },
-  "data": {
-    // the data
-  }
-})
-</pre>
+    /**/foo({
+      "meta": {
+        "status": 200,
+        "X-RateLimit-Limit": "5000",
+        "X-RateLimit-Remaining": "4966",
+        "X-RateLimit-Reset": "1372700873",
+        "Link": [ // pagination headers and other links
+          ["https://api.github.com?page=2", {"rel": "next"}]
+        ]
+      },
+      "data": {
+        // the data
+      }
+    })
 
 You can write a JavaScript handler to process the callback. Here's a minimal example you can try out:
 
@@ -628,6 +607,7 @@ how these timestamps can be specified.
 It is possible to supply a `Time-Zone` header which defines a timezone according
 to the [list of names from the Olson database](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones).
 
+{:.terminal}
     $ curl -H "Time-Zone: Europe/Amsterdam" -X POST https://api.github.com/repos/github/linguist/contents/new_file.md
 
 This means that we generate a timestamp for the moment your API call is made in

--- a/content/v3/activity/events.md
+++ b/content/v3/activity/events.md
@@ -16,6 +16,7 @@ rate limit will be untouched.  There is also an "X-Poll-Interval" header that
 specifies how often (in seconds) you are allowed to poll.  In times of high
 server load, the time may increase.  Please obey the header.
 
+{:.terminal}
     $ curl -I https://api.github.com/users/tater/events
     HTTP/1.1 200 OK
     X-Poll-Interval: 60

--- a/content/v3/activity/notifications.md
+++ b/content/v3/activity/notifications.md
@@ -36,6 +36,7 @@ leaving your current rate limit untouched.  There is an "X-Poll-Interval"
 header that specifies how often (in seconds) you are allowed to poll.  In times
 of high server load, the time may increase.  Please obey the header.
 
+{:.terminal}
     # Add authentication to your requests
     $ curl -I https://api.github.com/notifications
     HTTP/1.1 200 OK

--- a/content/v3/auth.md
+++ b/content/v3/auth.md
@@ -33,18 +33,16 @@ For example, if you're accessing the API via [cURL][curl], the following command
 would authenticate you if you replace `<username>` with your GitHub username.
 (cURL will prompt you to enter the password.)
 
-<pre class='terminal'>
-$ curl -u &lt;username&gt; https://api.github.com/user
-</pre>
+{:.terminal}
+    $ curl -u <username> https://api.github.com/user
 
 ### Via OAuth Tokens
 
 Alternatively, you can use [personal access
 tokens][personal-access-tokens] or OAuth tokens instead of your password. 
 
-<pre class='terminal'>
-$ curl -u &lt;username&gt;:&lt;token&gt; https://api.github.com/user
-</pre>
+{:.terminal}
+    $ curl -u <username>:<token> https://api.github.com/user
 
 This approach is useful if your tools only support Basic Authentication but you
 want to take advantage of OAuth access token security features.

--- a/content/v3/media.md
+++ b/content/v3/media.md
@@ -45,6 +45,7 @@ put the version before the property:
 You can check the current version through every response's headers.  Look
 for the `X-GitHub-Media-Type` header:
 
+{:.terminal}
     $ curl https://api.github.com/users/technoweenie -I
     HTTP/1.1 200 OK
     X-GitHub-Media-Type: github.v3

--- a/content/v3/oauth.md
+++ b/content/v3/oauth.md
@@ -122,6 +122,7 @@ cleaner approach is to include it in the Authorization header
 
 For example, in curl you can set the Authorization header like this:
 
+{:.terminal}
     curl -H "Authorization: token OAUTH-TOKEN" https://api.github.com/user
 
 ## Non-Web Application Flow
@@ -163,6 +164,7 @@ authorize form.
 Check headers to see what OAuth scopes you have, and what the API action
 accepts.
 
+{:.terminal}
     $ curl -H "Authorization: token OAUTH-TOKEN" https://api.github.com/users/technoweenie -I
     HTTP/1.1 200 OK
     X-OAuth-Scopes: repo, user

--- a/content/v3/repos/contents.md
+++ b/content/v3/repos/contents.md
@@ -265,13 +265,12 @@ Name | Type | Description
 
 To follow redirects with curl, use the `-L` switch:
 
-<pre class="terminal">
-curl -L https://api.github.com/repos/octokit/octokit.rb/tarball > octokit.tar.gz
+{:.terminal}
+    curl -L https://api.github.com/repos/octokit/octokit.rb/tarball > octokit.tar.gz
 
-  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
-                                 Dload  Upload   Total   Spent    Left  Speed
-100  206k  100  206k    0     0   146k      0  0:00:01  0:00:01 --:--:--  790k
-</pre>
+      % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
+                                     Dload  Upload   Total   Spent    Left  Speed
+    100  206k  100  206k    0     0   146k      0  0:00:01  0:00:01 --:--:--  790k
 
 ## Custom media types
 

--- a/content/v3/repos/hooks.md
+++ b/content/v3/repos/hooks.md
@@ -188,6 +188,7 @@ The GitHub PubSubHubbub endpoint is: https://api.github.com/hub.
 PubSubHubbub endpoint, but not change the `hub.topic` URI format.) A
 successful request with curl looks like:
 
+{:.terminal}
     curl -u "user" -i \
       https://api.github.com/hub \
       -F "hub.mode=subscribe" \

--- a/content/v3/search.md
+++ b/content/v3/search.md
@@ -105,6 +105,7 @@ use case. To get this metadata in your search results, specify the `text-match`
 media type in your Accept header. For example, via curl, the above query would
 look like this:
 
+{:.terminal}
     curl -H 'Accept: application/vnd.github.v3.text-match+json' \
       'https://api.github.com/search/repositories?q=tetris+language:assembly&sort=stars&order=desc'
 
@@ -190,6 +191,7 @@ use case. To get this metadata in your search results, specify the `text-match`
 media type in your Accept header. For example, via curl, the above query would
 look like this:
 
+{:.terminal}
     curl -H 'Accept: application/vnd.github.v3.text-match+json' \
       https://api.github.com/search/code?q=addClass+in:file+language:js+repo:jquery/jquery
 
@@ -291,6 +293,7 @@ use case. To get this metadata in your search results, specify the `text-match`
 media type in your Accept header. For example, via curl, the above query would
 look like this:
 
+{:.terminal}
     curl -H 'Accept: application/vnd.github.v3.text-match+json' \
       'https://api.github.com/search/issues?q=windows+label:bug+language:python+state:open&sort=created&order=asc'
 
@@ -361,6 +364,7 @@ use case. To get this metadata in your search results, specify the `text-match`
 media type in your Accept header. For example, via curl, the above query would
 look like this:
 
+{:.terminal}
     curl -H 'Accept: application/vnd.github.v3.text-match+json' \
       https://api.github.com/search/users?q=tom+repos:%3E42+followers:%3E1000
 
@@ -409,6 +413,7 @@ Name | Description
 Using curl, and the [example issue search](#issue-search-example) above, our API
 request would look like this:
 
+{:.terminal}
     curl -H 'Accept: application/vnd.github.v3.text-match+json' \
       'https://api.github.com/search/issues?q=windows+label:bug+language:python+state:open&sort=created&order=asc'
 

--- a/content/webhooks/index.md
+++ b/content/webhooks/index.md
@@ -99,40 +99,39 @@ Also, the `User-Agent` for the requests will have the prefix `GitHub-Hookshot/`.
 
 ### Example delivery
 
-<pre class="terminal">
-POST /payload HTTP/1.1
+{:.terminal}
+    POST /payload HTTP/1.1
 
-Host: localhost:4567
-X-Github-Delivery: 72d3162e-cc78-11e3-81ab-4c9367dc0958
-User-Agent: GitHub-Hookshot/044aadd
-Content-Type: application/json
-Content-Length: 6615
-X-Github-Event: issues
+    Host: localhost:4567
+    X-Github-Delivery: 72d3162e-cc78-11e3-81ab-4c9367dc0958
+    User-Agent: GitHub-Hookshot/044aadd
+    Content-Type: application/json
+    Content-Length: 6615
+    X-Github-Event: issues
 
-{
-  "action": "opened",
-  "issue": {
-    "url": "https://api.github.com/repos/octocat/Hello-World/issues/1347",
-    "number": 1347,
-    ...
-  },
-  "repository" : {
-    "id": 1296269,
-    "full_name": "octocat/Hello-World",
-    "owner": {
-      "login": "octocat",
-      "id": 1,
-      ...
-    },
-    ...
-  },
-  "sender": {
-    "login": "octocat",
-    "id": 1,
-    ...
-  }
-}
-</pre>
+    {
+      "action": "opened",
+      "issue": {
+        "url": "https://api.github.com/repos/octocat/Hello-World/issues/1347",
+        "number": 1347,
+        ...
+      },
+      "repository" : {
+        "id": 1296269,
+        "full_name": "octocat/Hello-World",
+        "owner": {
+          "login": "octocat",
+          "id": 1,
+          ...
+        },
+        ...
+      },
+      "sender": {
+        "login": "octocat",
+        "id": 1,
+        ...
+      }
+    }
 
 
 ## Ping Event


### PR DESCRIPTION
This has a few bonuses compared to manual `pre.terminal` elements.
It promotes readable authoring since code blocks are escaped automatically and the code examples are separated from the text.