### PR TITLE
call out for deprecation notices not being GHE

### DIFF
--- a/content/v3/orgs/teams.md
+++ b/content/v3/orgs/teams.md
@@ -192,7 +192,7 @@ authenticated user.
 
 ## Add team member
 
-### Deprecation notice
+### Deprecation notice (Not for GitHub Enterprise)
 
 <div class="alert">
   <p>


### PR DESCRIPTION
Is it worth while to add special call outs for these deprecation notices since they're **NOT** yet deprecated for GHE?

Just some background context:  we have [add-team-member (deprecated)](https://developer.github.com/v3/orgs/teams/#add-team-member) and [add-team-membership](https://developer.github.com/v3/orgs/teams/#add-team-membership) which should do the same thing. However, `add-team-membership` in GHE 2.3 does an invite (`status: pending`, which shouldn't be the case past GHE 2.3), instead of just adding the new user to a team. 