### PR TITLE
Use better code blocks for syntax highlighting

### DIFF
--- a/content/changes/2013-08-20-search-api-improvements.md
+++ b/content/changes/2013-08-20-search-api-improvements.md
@@ -14,27 +14,26 @@ Now, you can also [get this metadata][code-text-matches] for matches that occur 
 
 For example, when [searching for files that have "client" in their path][example-path-search], the results include this match for `lib/octokit/client/commits.rb`:
 
-<pre class="json">
-{
-  "name": "commits.rb",
-  "path": "lib/octokit/client/commits.rb",
-  "text_matches": [
+{:.json}
     {
-      "object_url": "https://api.github.com/repositories/417862/contents/lib/octokit/client/commits.rb?ref=8d487ab06ccef463aa9f5412a56f1a2f1fa4dc88",
-      "object_type": "FileContent",
-      "property": "path",
-      "fragment": "lib/octokit/client/commits.rb",
-      "matches": [
+      "name": "commits.rb",
+      "path": "lib/octokit/client/commits.rb",
+      "text_matches": [
         {
-          "text": "client",
-          "indices": [ 12, 18 ]
+          "object_url": "https://api.github.com/repositories/417862/contents/lib/octokit/client/commits.rb?ref=8d487ab06ccef463aa9f5412a56f1a2f1fa4dc88",
+          "object_type": "FileContent",
+          "property": "path",
+          "fragment": "lib/octokit/client/commits.rb",
+          "matches": [
+            {
+              "text": "client",
+              "indices": [ 12, 18 ]
+            }
+          ]
         }
       ]
+      // ...
     }
-  ]
-  // ...
-}
-</pre>
 
 ## Better Text Match Metadata
 
@@ -45,23 +44,21 @@ For example, imagine your search returns an issue like [rails/rails#11889][examp
 
 The response would include a `text_matches` array with the following object:
 
-<pre class="json">
-{
-  "fragment": "undefined method `except' for #&amp;lt;Array:XXX&amp;gt;",
-  // ...
-}
-</pre>
+{:.json}
+    {
+      "fragment": "undefined method 'except' for #&lt;Array:XXX&gt;",
+      // ...
+    }
 
 Inside the `fragment` value, we see HTML-encoded entities (e.g., `&lt;`).
 Since we're returning JSON (not HTML), API clients might not expect any HTML-encoded text.
 As of today, the API returns these fragments _without_ this extraneous encoding.
 
-<pre class="json">
-{
-  "fragment": "undefined method `except' for #&lt;Array:XXX&gt;",
-  // ...
-}
-</pre>
+{:.json}
+    {
+      "fragment": "undefined method 'except' for #<Array:XXX>",
+      // ...
+    }
 
 ## Preview Period
 

--- a/content/changes/2013-10-04-oauth-changes-coming.html
+++ b/content/changes/2013-10-04-oauth-changes-coming.html
@@ -10,13 +10,12 @@ Starting today, we are returning granted scopes as part of the
 For example, if you are making a POST with the `application/json`
 mime-type you'll see an additional field for the granted scopes.
 
-<pre><code class="language-javascript">
-{
-  "access_token":"e72e16c7e42f292c6912e7710c838347ae178b4a",
-  "scope":"repo,gist",
-  "token_type":"bearer"
-}
-</code></pre>
+    #!javascript
+    {
+      "access_token":"e72e16c7e42f292c6912e7710c838347ae178b4a",
+      "scope":"repo,gist",
+      "token_type":"bearer"
+    }
 
 Right now, these scopes will be identical to what you requested, but we
 are moving towards a feature set that will allow GitHub users to edit

--- a/content/changes/2014-05-19-deployments-api-updates.md
+++ b/content/changes/2014-05-19-deployments-api-updates.md
@@ -25,70 +25,68 @@ The Deployment Status payloads now embed the associated Deployment object. With 
 
 ### Example Deployment JSON
 
-<pre><code class="language-javascript">
-{
-  "url": "https://api.github.com/repos/my-org/my-repo/deployments/392",
-  "id": 392,
-  "sha": "837db83be4137ca555d9a5598d0a1ea2987ecfee",
-  "ref": "master",
-  "environment": "staging",
-  "payload": {
-    "fe": [
-      "fe1",
-      "fe2",
-      "fe3"
-    ]
-  },
-  "description": "ship it!",
-  "creator": {
-    "login": "my-org",
-    "id": 521,
-    "avatar_url": "https://avatars.githubusercontent.com/u/2988?",
-    "type": "User"
-  },
-  "created_at": "2014-05-09T19:56:47Z",
-  "updated_at": "2014-05-09T19:56:47Z",
-  "statuses_url": "https://api.github.com/repos/my-org/my-repo/deployments/392/statuses"
-}
-</code></pre>
+    #!javascript
+    {
+      "url": "https://api.github.com/repos/my-org/my-repo/deployments/392",
+      "id": 392,
+      "sha": "837db83be4137ca555d9a5598d0a1ea2987ecfee",
+      "ref": "master",
+      "environment": "staging",
+      "payload": {
+        "fe": [
+          "fe1",
+          "fe2",
+          "fe3"
+        ]
+      },
+      "description": "ship it!",
+      "creator": {
+        "login": "my-org",
+        "id": 521,
+        "avatar_url": "https://avatars.githubusercontent.com/u/2988?",
+        "type": "User"
+      },
+      "created_at": "2014-05-09T19:56:47Z",
+      "updated_at": "2014-05-09T19:56:47Z",
+      "statuses_url": "https://api.github.com/repos/my-org/my-repo/deployments/392/statuses"
+    }
 
 ### Example Deployment Status JSON
 
-<pre><code class="language-javascript">
-{
-  "url": "https://api.github.com/repos/my-org/my-repo/deployments/396/statuses/1",
-  "id": 1,
-  "state": "success",
-  "deployment": {
-    "url": "https://api.github.com/repos/my-org/my-repo/deployments/396",
-    "id": 392,
-    "sha": "837db83be4137ca555d9a5598d0a1ea2987ecfee",
-    "ref": "master",
-    "payload": {
-      "fe": [
-        "fe1",
-        "fe2",
-        "fe3"
-      ]
-    },
-    "environment": "production",
-    "description": "Deploying to production",
-    "creator": {
-      "login": "alysson-goldner",
-      "id": 540,
-      "type": "User"
-    },
-    "created_at": "2014-05-09T19:59:36Z",
-    "updated_at": "2014-05-09T19:59:36Z",
-    "statuses_url": "https://api.github.com/repos/my-org/my-repo/deployments/396/statuses"
-  },
-  "description": "Deployment succeeded",
-  "target_url": "https://deploy.myorg.com/apps/my-repo/logs/420",
-  "created_at": "2014-05-09T19:59:39Z",
-  "updated_at": "2014-05-09T19:59:39Z",
-  "deployment_url": "https://api.github.com/repos/my-org/my-repo/deployments/396"
-}
-</code></pre>
+    #!javascript
+    {
+      "url": "https://api.github.com/repos/my-org/my-repo/deployments/396/statuses/1",
+      "id": 1,
+      "state": "success",
+      "deployment": {
+        "url": "https://api.github.com/repos/my-org/my-repo/deployments/396",
+        "id": 392,
+        "sha": "837db83be4137ca555d9a5598d0a1ea2987ecfee",
+        "ref": "master",
+        "payload": {
+          "fe": [
+            "fe1",
+            "fe2",
+            "fe3"
+          ]
+        },
+        "environment": "production",
+        "description": "Deploying to production",
+        "creator": {
+          "login": "alysson-goldner",
+          "id": 540,
+          "type": "User"
+        },
+        "created_at": "2014-05-09T19:59:36Z",
+        "updated_at": "2014-05-09T19:59:36Z",
+        "statuses_url": "https://api.github.com/repos/my-org/my-repo/deployments/396/statuses"
+      },
+      "description": "Deployment succeeded",
+      "target_url": "https://deploy.myorg.com/apps/my-repo/logs/420",
+      "created_at": "2014-05-09T19:59:39Z",
+      "updated_at": "2014-05-09T19:59:39Z",
+      "deployment_url": "https://api.github.com/repos/my-org/my-repo/deployments/396"
+    }
 
 If you have any questions or feedback, please [get in touch][contact].
 

--- a/content/changes/2014-09-12-changing-organization-feeds.md
+++ b/content/changes/2014-09-12-changing-organization-feeds.md
@@ -14,10 +14,9 @@ use of these attributes, you'll want to update your code to use the new
 
 Previously, the deprecated attributes returned URI template. For example:
 
-<pre><code class="language-javascript">
-"current_user_organization_url":
-  "https://github.com/organizations/{org}/mastahyeti.private.atom?token=abc123"
-</code></pre>
+    #!javascript
+    "current_user_organization_url":
+      "https://github.com/organizations/{org}/mastahyeti.private.atom?token=abc123"
 
 The template included a deprecated authentication token. Our new tokens are
 valid only for a concrete feed URL (not for a URI template). Because the
@@ -32,12 +31,11 @@ In order to preserve the functionality of this API, we have added a new
 attribute that lists specific Atom feed urls for each of the user's
 organizations.
 
-<pre><code class="language-javascript">
-"current_user_organization_urls": [
-  "https://github.com/organizations/github/mastahyeti.private.atom?token=abc123"
-  "https://github.com/organizations/requests/mastahyeti.private.atom?token=token=def456"
-]
-</code></pre>
+    #!javascript
+    "current_user_organization_urls": [
+      "https://github.com/organizations/github/mastahyeti.private.atom?token=abc123"
+      "https://github.com/organizations/requests/mastahyeti.private.atom?token=token=def456"
+    ]
 
 Check out the updated [Feeds API documentation][docs] for the new fields. If you
 have any questions or feedback, please [get drop us a line][contact].

--- a/content/changes/2014-10-21-deployment-webhook-payload-changes.md
+++ b/content/changes/2014-10-21-deployment-webhook-payload-changes.md
@@ -13,140 +13,132 @@ This change brings the payloads for these events more inline with the responses 
 
 #### Old Format
 
-<pre><code class="language-javascript">
-{
-  "id": 42,
-  "sha": "deadbeef",
-  "ref": "master",
-  "task": "deploy",
-  "name": "my-org/our-app",
-  "environment": "production",
-  "payload": {…},
-  "description": "Deploying master",
-  "repository": {…},
-  "sender": {…}
-}
-
-</code></pre>
+    #!javascript
+    {
+      "id": 42,
+      "sha": "deadbeef",
+      "ref": "master",
+      "task": "deploy",
+      "name": "my-org/our-app",
+      "environment": "production",
+      "payload": {…},
+      "description": "Deploying master",
+      "repository": {…},
+      "sender": {…}
+    }
 
 #### Current Format - 2014/10/22
 
-<pre><code class="language-javascript">
-{
-  "id": 42,
-  "sha": "deadbeef",
-  "ref": "master",
-  "task": "deploy",
-  "name": "my-org/our-app",
-  "environment": "production",
-  "payload": {…},
-  "description": "Deploying master",
-  "repository": {…},
-  "deployment": {
-    "url": "https://api.github.com/repos/my-org/our-app/deployments/42",
-    "id": 42,
-    "sha": "deadbeef",
-    "ref": "master",
-    "task": "deploy",
-    "environment": "production",
-    "payload": {…},
-    "description": "Deploying master",
-    "creator": {…},
-    "created_at": "2014-09-23T16:37:49Z",
-    "updated_at": "2014-09-23T16:37:49Z",
-    "statuses_url": "https://api.github.com/repos/my-org/our-app/deployments/42/statuses"
-  },
-  "sender": {…}
-}
-
-</code></pre>
+    #!javascript
+    {
+      "id": 42,
+      "sha": "deadbeef",
+      "ref": "master",
+      "task": "deploy",
+      "name": "my-org/our-app",
+      "environment": "production",
+      "payload": {…},
+      "description": "Deploying master",
+      "repository": {…},
+      "deployment": {
+        "url": "https://api.github.com/repos/my-org/our-app/deployments/42",
+        "id": 42,
+        "sha": "deadbeef",
+        "ref": "master",
+        "task": "deploy",
+        "environment": "production",
+        "payload": {…},
+        "description": "Deploying master",
+        "creator": {…},
+        "created_at": "2014-09-23T16:37:49Z",
+        "updated_at": "2014-09-23T16:37:49Z",
+        "statuses_url": "https://api.github.com/repos/my-org/our-app/deployments/42/statuses"
+      },
+      "sender": {…}
+    }
 
 #### New Format - 2014/11/05
 
-<pre><code class="language-javascript">
-{
-  "deployment": {
-    "url": "https://api.github.com/repos/my-org/our-app/deployments/42",
-    "id": 42,
-    "sha": "deadbeef",
-    "ref": "master",
-    "task": "deploy",
-    "environment": "production",
-    "payload": {…},
-    "description": "Deploying master",
-    "creator": {…},
-    "created_at": "2014-09-23T16:37:49Z",
-    "updated_at": "2014-09-23T16:37:49Z",
-    "statuses_url": "https://api.github.com/repos/my-org/our-app/deployments/42/statuses"
-  },
-  "repository": {…},
-  "sender": {…}
-}
-</code></pre>
+    #!javascript
+    {
+      "deployment": {
+        "url": "https://api.github.com/repos/my-org/our-app/deployments/42",
+        "id": 42,
+        "sha": "deadbeef",
+        "ref": "master",
+        "task": "deploy",
+        "environment": "production",
+        "payload": {…},
+        "description": "Deploying master",
+        "creator": {…},
+        "created_at": "2014-09-23T16:37:49Z",
+        "updated_at": "2014-09-23T16:37:49Z",
+        "statuses_url": "https://api.github.com/repos/my-org/our-app/deployments/42/statuses"
+      },
+      "repository": {…},
+      "sender": {…}
+    }
 
 ## DeploymentStatusEvent Changes
 
 #### Old Format
 
-<pre><code class="language-javascript">
-{
-  "id": 2600,
-  "state": "success",
-  "deployment": {…},
-  "target_url": "https://gist.github.com/deadbeef",
-  "description": "Deployment was successful",
-  "repository": {…},
-  "sender": {…}
-}
-</code></pre>
+    #!javascript
+    {
+      "id": 2600,
+      "state": "success",
+      "deployment": {…},
+      "target_url": "https://gist.github.com/deadbeef",
+      "description": "Deployment was successful",
+      "repository": {…},
+      "sender": {…}
+    }
 
 #### Current Format - 2014/10/22
 
-<pre><code class="language-javascript">
-{
-  "id": 2600,
-  "state": "success",
-  "target_url": "https://gist.github.com/deadbeef",
-  "description": "Deployment was successful",
-  "repository": {…},
-  "deployment_status": {
-    "url": "https://api.github.com/repos/my-org/our-app/deployments/42/statuses2600",
-    "id": 2600,
-    "state": "success",
-    "creator": {…},
-    "target_url": "https://gist.github.com/deadbeef",
-    "description": "Deployment was successful",
-    "created_at": "2014-09-23T16:45:49Z",
-    "updated_at": "2014-09-23T16:45:49Z",
-    "deployment_url": "https://api.github.com/repos/my-org/our-app/deployments/42",
-    "repository_url": "https://api.github.com/repos/my-org/our-app"
-  },
-  "deployment": {…},
-  "sender": {…}
-}
-</code></pre>
+    #!javascript
+    {
+      "id": 2600,
+      "state": "success",
+      "target_url": "https://gist.github.com/deadbeef",
+      "description": "Deployment was successful",
+      "repository": {…},
+      "deployment_status": {
+        "url": "https://api.github.com/repos/my-org/our-app/deployments/42/statuses2600",
+        "id": 2600,
+        "state": "success",
+        "creator": {…},
+        "target_url": "https://gist.github.com/deadbeef",
+        "description": "Deployment was successful",
+        "created_at": "2014-09-23T16:45:49Z",
+        "updated_at": "2014-09-23T16:45:49Z",
+        "deployment_url": "https://api.github.com/repos/my-org/our-app/deployments/42",
+        "repository_url": "https://api.github.com/repos/my-org/our-app"
+      },
+      "deployment": {…},
+      "sender": {…}
+    }
 
 #### New Format - 2014/11/05
 
-<pre><code class="language-javascript">
-{
-  "deployment_status": {
-    "url": "https://api.github.com/repos/my-org/our-app/deployments/42/statuses2600",
-    "id": 2600,
-    "state": "success",
-    "creator": {…},
-    "target_url": "https://gist.github.com/deadbeef",
-    "description": "Deployment was successful",
-    "created_at": "2014-09-23T16:45:49Z",
-    "updated_at": "2014-09-23T16:45:49Z",
-    "deployment_url": "https://api.github.com/repos/my-org/our-app/deployments/42",
-    "repository_url": "https://api.github.com/repos/my-org/our-app"
-  },
-  "deployment": {…},
-  "repository": {…},
-  "sender": {…}
-}
-</code></pre>
+    #!javascript
+    {
+      "deployment_status": {
+        "url": "https://api.github.com/repos/my-org/our-app/deployments/42/statuses2600",
+        "id": 2600,
+        "state": "success",
+        "creator": {…},
+        "target_url": "https://gist.github.com/deadbeef",
+        "description": "Deployment was successful",
+        "created_at": "2014-09-23T16:45:49Z",
+        "updated_at": "2014-09-23T16:45:49Z",
+        "deployment_url": "https://api.github.com/repos/my-org/our-app/deployments/42",
+        "repository_url": "https://api.github.com/repos/my-org/our-app"
+      },
+      "deployment": {…},
+      "repository": {…},
+      "sender": {…}
+    }
 
 If you have any questions or feedback, please [get in touch][get-in-touch].
 

--- a/content/changes/2015-06-11-pages-a-records.md
+++ b/content/changes/2015-06-11-pages-a-records.md
@@ -10,22 +10,21 @@ The [Meta API](/v3/meta/) now includes the A record IP addresses for [GitHub Pag
 {:.terminal}
     $ curl https://api.github.com/meta
 
-<pre><code class="language-javascript">
-{
-  "verifiable_password_authentication": true,
-  "github_services_sha": "23c6105183b626cf74c045f6d53af7a178bfdb4c",
-  "hooks": [
-    "192.30.252.0/22"
-  ],
-  "git": [
-    "192.30.252.0/22"
-  ],
-  "pages": [
-    "192.30.252.153/32",
-    "192.30.252.154/32"
-  ]
-}
-</code></pre>
+    #!javascript
+    {
+      "verifiable_password_authentication": true,
+      "github_services_sha": "23c6105183b626cf74c045f6d53af7a178bfdb4c",
+      "hooks": [
+        "192.30.252.0/22"
+      ],
+      "git": [
+        "192.30.252.0/22"
+      ],
+      "pages": [
+        "192.30.252.153/32",
+        "192.30.252.154/32"
+      ]
+    }
 
 These IP addresses are used to [configure A records with your DNS provider for GitHub Pages](https://help.github.com/articles/tips-for-configuring-an-a-record-with-your-dns-provider/). These addresses have changed a few times in the past. This API always provides the current addresses so that you can automate the process of keeping your DNS records up to date.
 

--- a/content/v3.md
+++ b/content/v3.md
@@ -351,10 +351,9 @@ Header Name | Description
 
 If you need the time in a different format, any modern programming language can get the job done. For example, if you open up the console on your web browser, you can easily get the reset time as a JavaScript Date object.
 
-<pre><code class="language-javascript">
-new Date(1372700873 * 1000)
-// => Mon Jul 01 2013 13:47:53 GMT-0400 (EDT)
-</code></pre>
+    #!javascript
+    new Date(1372700873 * 1000)
+    // => Mon Jul 01 2013 13:47:53 GMT-0400 (EDT)
 
 Once you go over the rate limit you will receive an error response:
 


### PR DESCRIPTION
This separates the code blocks from the text and encourages
authoring as-is, since no escaping is necessary.