### PR TITLE
Changes the default POST url for creating statuses

### DIFF
--- a/content/v3/repos/statuses.md
+++ b/content/v3/repos/statuses.md
@@ -35,7 +35,14 @@ access to Statuses **without** also granting access to repository code, while th
 
 Users with push access can create commit statuses for a given ref:
 
-    POST /repos/:owner/:repo/statuses/:sha
+    POST /repos/:owner/:repo/commits/:sha/statuses
+    
+<div class="alert">
+  <p>
+    This resource is also available via a legacy route:
+    <code>GET /repos/:owner/:repo/statuses/:sha</code>.
+  </p>
+</div>
 
 Note: there is a limit of 1000 statuses per `sha` and `context` within a Repository.
 Attempts to create more than 1000 statuses will result in a validation error.


### PR DESCRIPTION
I just implemented this functionality in Ghee https://github.com/rauhryan/ghee/pull/34

Creating statuses felt like an outlier in terms of the url schemes throughout the rest of the API, so I took a shot and POST'd to `/repos/:owner/:repo/commits/:sha/statuses` and it works

Please let me know if this is unintentional but I assume that `/repos/:owner/:repo/statuses/:sha` is now a legacy route