### PR TITLE
Fix minor grammatical issue on a help page

### DIFF
--- a/content/guides/discovering-resources-for-a-user.md
+++ b/content/guides/discovering-resources-for-a-user.md
@@ -7,7 +7,7 @@ title: Discovering resources for a user | GitHub API
 * TOC
 {:toc}
 
-When making authenticated requests to the GitHub API, applications often need to fetch the current user's repositories and organizations. In this guide, will explain how to reliably discover those resources.
+When making authenticated requests to the GitHub API, applications often need to fetch the current user's repositories and organizations. In this guide, we'll explain how to reliably discover those resources.
 
 To interact with the GitHub API, we'll be using [Octokit.rb][octokit.rb]. You can find the complete source code for this project in the [platform-samples][platform samples] repository.
 


### PR DESCRIPTION
Added a missing subject to a sentence.
I chose *__we__'ll* instead of *__we__ will* because it is more common in this repository.