### PR TITLE
Fix README for Nanoc 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,15 +133,6 @@ $ bundle exec nanoc view
 $ open http://localhost:3000
 ```
 
-Compilation times got you down?  Use `autocompile`!
-
-```sh
-$ bundle exec nanoc autocompile
-```
-
-This starts a web server too, so there's no need to run `nanoc view`.
-One thing: remember to add trailing slashes to all nanoc links!
-
 ## Deploy
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ All submissions are welcome. To submit a change, fork this repo, commit your cha
 
 ## Setup
 
-Ruby 1.9 is required to build the site.
+Ruby 2.2 is required to build the site.
 
 Get the nanoc gem, plus kramdown for Markdown parsing:
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # developer.github.com
 
-This is a GitHub API resource built with [nanoc][nanoc].
+This is a GitHub API resource built with [Nanoc][nanoc].
 
 All submissions are welcome. To submit a change, fork this repo, commit your changes, and send us a [pull request](http://help.github.com/send-pull-requests/).
 
@@ -8,19 +8,19 @@ All submissions are welcome. To submit a change, fork this repo, commit your cha
 
 Ruby 2.2 is required to build the site.
 
-Get the nanoc gem, plus kramdown for Markdown parsing:
+Get the Nanoc gem, plus kramdown for Markdown parsing:
 
 ```sh
 $ bundle install
 ```
 
-You can see the available commands with nanoc:
+You can see the available commands with Nanoc:
 
 ```sh
 $ bundle exec nanoc -h
 ```
 
-Nanoc has [some nice documentation](http://nanoc.ws/docs/tutorial/) to get you started.  Though if you're mainly concerned with editing or adding content, you won't need to know much about nanoc.
+Nanoc has [some nice documentation](http://nanoc.ws/docs/tutorial/) to get you started.  Though if you're mainly concerned with editing or adding content, you won't need to know much about Nanoc.
 
 [nanoc]: http://nanoc.ws/
 


### PR DESCRIPTION
* Specify the proper required Ruby version (2.2, rather than 1.9)

* Remove mention of autocompile, because it’s replaced with [guard-nanoc](https://github.com/guard/guard-nanoc)—and this repo is already using it anyway.

* Fix name (Nanoc vs nanoc)