### PR TITLE
Add -k flag and https to 2 examples

### DIFF
--- a/content/v3/enterprise/management_console.md
+++ b/content/v3/enterprise/management_console.md
@@ -69,7 +69,7 @@ For a list of the available settings, see [the `/setup/api/settings` endpoint](#
 ### Example
 
 ``` command-line
-$ curl -L -X -k POST 'https://<em>hostname</em>:<em>admin_port</em>/setup/api/start' -F license=@<em>/path/to/github-enterprise.ghl</em> -F "password=<em>your-amazing-password</em>" -F settings=&lt;<em>/path/to/settings.json</em>
+$ curl -L -X POST -k 'https://<em>hostname</em>:<em>admin_port</em>/setup/api/start' -F license=@<em>/path/to/github-enterprise.ghl</em> -F "password=<em>your-amazing-password</em>" -F settings=&lt;<em>/path/to/settings.json</em>
 ```
 
 ## Upgrade a license
@@ -259,7 +259,7 @@ Name | Type | Description
 ### Example
 
 ``` command-line
-$ curl -L -X -k POST 'https://api_key:<em>your-amazing-password</em>@<em>hostname</em>:<em>admin_port</em>/setup/api/settings/authorized-keys' -F authorized_key=@<em>/path/to/key.pub</em>
+$ curl -L -X POST -k 'https://api_key:<em>your-amazing-password</em>@<em>hostname</em>:<em>admin_port</em>/setup/api/settings/authorized-keys' -F authorized_key=@<em>/path/to/key.pub</em>
 ```
 
 ## Remove an authorized SSH key

--- a/content/v3/enterprise/management_console.md
+++ b/content/v3/enterprise/management_console.md
@@ -14,6 +14,8 @@ You must explicitly set the port number when making API calls to the Management 
 
 If you don't want to provide a port number, you'll need to configure your tool to automatically follow redirects.
 
+You may also need to add the [`-k` flag](http://curl.haxx.se/docs/manpage.html#-k) when using `curl`, since GitHub Enterprise uses a self-signed certificate before you [add your own SSL certificate](https://help.github.com/enterprise/admin/guides/installation/dns-hostname-subdomain-isolation-and-ssl/#ssl).
+
 {{/tip}}
 
 ## Authentication
@@ -46,8 +48,6 @@ When using this endpoint, your Enterprise instance must have a password set. Thi
 
 1. If you're working directly with the API before accessing the web interface, you must pass in the password parameter to set your password.
 2. If you set up your instance via the web interface before accessing the API, your calls to this endpoint do not need the password parameter.
-
-You may also need to add the `-k` flag when using `curl`, since GitHub Enterprise uses a self-signed certificate before you [add your own SSL certificate](https://help.github.com/enterprise/admin/guides/installation/dns-hostname-subdomain-isolation-and-ssl/#ssl).
 
 {{/warning}}
 

--- a/content/v3/enterprise/management_console.md
+++ b/content/v3/enterprise/management_console.md
@@ -47,6 +47,8 @@ When using this endpoint, your Enterprise instance must have a password set. Thi
 1. If you're working directly with the API before accessing the web interface, you must pass in the password parameter to set your password.
 2. If you set up your instance via the web interface before accessing the API, your calls to this endpoint do not need the password parameter.
 
+You may also need to use the `-k` flag, as GitHub Enterprise uses a self-signed certificate before you [enable your own SSL certificate](https://help.github.com/enterprise/admin/guides/installation/dns-hostname-subdomain-isolation-and-ssl/#ssl).
+
 {{/warning}}
 
 ### Parameters
@@ -69,7 +71,7 @@ For a list of the available settings, see [the `/setup/api/settings` endpoint](#
 ### Example
 
 ``` command-line
-$ curl -L -X POST -k 'https://<em>hostname</em>:<em>admin_port</em>/setup/api/start' -F license=@<em>/path/to/github-enterprise.ghl</em> -F "password=<em>your-amazing-password</em>" -F settings=&lt;<em>/path/to/settings.json</em>
+$ curl -L -X POST 'https://<em>hostname</em>:<em>admin_port</em>/setup/api/start' -F license=@<em>/path/to/github-enterprise.ghl</em> -F "password=<em>your-amazing-password</em>" -F settings=&lt;<em>/path/to/settings.json</em>
 ```
 
 ## Upgrade a license
@@ -259,7 +261,7 @@ Name | Type | Description
 ### Example
 
 ``` command-line
-$ curl -L -X POST -k 'https://api_key:<em>your-amazing-password</em>@<em>hostname</em>:<em>admin_port</em>/setup/api/settings/authorized-keys' -F authorized_key=@<em>/path/to/key.pub</em>
+$ curl -L -X POST 'https://api_key:<em>your-amazing-password</em>@<em>hostname</em>:<em>admin_port</em>/setup/api/settings/authorized-keys' -F authorized_key=@<em>/path/to/key.pub</em>
 ```
 
 ## Remove an authorized SSH key

--- a/content/v3/enterprise/management_console.md
+++ b/content/v3/enterprise/management_console.md
@@ -23,13 +23,13 @@ You need to pass your [Management Console password](https://help.github.com/ente
 Use the `api_key` parameter to send this token with each request. For example:
 
 ``` command-line
-$ curl -L 'http://<em>hostname</em>:<em>admin_port</em>/setup/api?api_key=<em>your-amazing-password</em>'
+$ curl -L 'https://<em>hostname</em>:<em>admin_port</em>/setup/api?api_key=<em>your-amazing-password</em>'
 ```
 
 You can also use standard HTTP authentication to send this token. For example:
 
 ``` command-line
-$ curl -L 'http://api_key:<em>your-amazing-password</em>@<em>hostname</em>:<em>admin_port</em>/setup/api'
+$ curl -L 'https://api_key:<em>your-amazing-password</em>@<em>hostname</em>:<em>admin_port</em>/setup/api'
 ```
 
 ## Upload a license for the first time
@@ -96,7 +96,7 @@ Name | Type | Description
 ### Example
 
 ``` command-line
-$ curl -L -X POST 'http://api_key:<em>your-amazing-password</em>@<em>hostname</em>:<em>admin_port</em>/setup/api/upgrade'
+$ curl -L -X POST 'https://api_key:<em>your-amazing-password</em>@<em>hostname</em>:<em>admin_port</em>/setup/api/upgrade'
 ```
 
 ## Check configuration status
@@ -125,7 +125,7 @@ Status        | Description
 ### Example
 
 ``` command-line
-$ curl -L 'http://api_key:<em>your-amazing-password</em>@<em>hostname</em>:<em>admin_port</em>/setup/api/configcheck'
+$ curl -L 'https://api_key:<em>your-amazing-password</em>@<em>hostname</em>:<em>admin_port</em>/setup/api/configcheck'
 ```
 
 ## Start a configuration process
@@ -144,7 +144,7 @@ This endpoint allows you to start a configuration process at any time for your u
 ### Example
 
 ``` command-line
-$ curl -L -X POST 'http://api_key:<em>your-amazing-password</em>@<em>hostname</em>:<em>admin_port</em>/setup/api/configure'
+$ curl -L -X POST 'https://api_key:<em>your-amazing-password</em>@<em>hostname</em>:<em>admin_port</em>/setup/api/configure'
 ```
 
 ## Retrieve settings
@@ -159,7 +159,7 @@ $ curl -L -X POST 'http://api_key:<em>your-amazing-password</em>@<em>hostname</e
 ### Example
 
 ``` command-line
-$ curl -L 'http://api_key:<em>your-amazing-password</em>@<em>hostname</em>:<em>admin_port</em>/setup/api/settings'
+$ curl -L 'https://api_key:<em>your-amazing-password</em>@<em>hostname</em>:<em>admin_port</em>/setup/api/settings'
 ```
 
 ## Modify settings
@@ -181,7 +181,7 @@ Name | Type | Description
 ### Example
 
 ``` command-line
-$ curl -L -X PUT 'http://api_key:<em>your-amazing-password</em>@<em>hostname</em>:<em>admin_port</em>/setup/api/settings' --data-urlencode "settings=`cat /path/to/settings.json`"
+$ curl -L -X PUT 'https://api_key:<em>your-amazing-password</em>@<em>hostname</em>:<em>admin_port</em>/setup/api/settings' --data-urlencode "settings=`cat /path/to/settings.json`"
 ```
 
 ## Check maintenance status
@@ -198,7 +198,7 @@ Check your installation's maintenance status:
 ### Example
 
 ``` command-line
-$ curl -L 'http://api_key:<em>your-amazing-password</em>@<em>hostname</em>:<em>admin_port</em>/setup/api/maintenance'
+$ curl -L 'https://api_key:<em>your-amazing-password</em>@<em>hostname</em>:<em>admin_port</em>/setup/api/maintenance'
 ```
 
 ## Enable or disable maintenance mode
@@ -225,7 +225,7 @@ The possible values for `when` are `now` or any date parseable by
 ### Example
 
 ``` command-line
-$ curl -L -X POST 'http://api_key:<em>your-amazing-password</em>@<em>hostname</em>:<em>admin_port</em>/setup/api/maintenance' -d 'maintenance=<em>{"enabled":true, "when":"now"}</em>'
+$ curl -L -X POST 'https://api_key:<em>your-amazing-password</em>@<em>hostname</em>:<em>admin_port</em>/setup/api/maintenance' -d 'maintenance=<em>{"enabled":true, "when":"now"}</em>'
 ```
 
 ## Retrieve authorized SSH keys
@@ -240,7 +240,7 @@ $ curl -L -X POST 'http://api_key:<em>your-amazing-password</em>@<em>hostname</e
 ### Example
 
 ``` command-line
-$ curl -L 'http://api_key:<em>your-amazing-password</em>@<em>hostname</em>:<em>admin_port</em>/setup/api/settings/authorized-keys'
+$ curl -L 'https://api_key:<em>your-amazing-password</em>@<em>hostname</em>:<em>admin_port</em>/setup/api/settings/authorized-keys'
 ```
 
 ## Add a new authorized SSH key
@@ -282,5 +282,5 @@ Name | Type | Description
 ### Example
 
 ``` command-line
-$ curl -L -X DELETE 'http://api_key:<em>your-amazing-password</em>@<em>hostname</em>:<em>admin_port</em>/setup/api/settings/authorized-keys' -F authorized_key=@<em>/path/to/key.pub</em>
+$ curl -L -X DELETE 'https://api_key:<em>your-amazing-password</em>@<em>hostname</em>:<em>admin_port</em>/setup/api/settings/authorized-keys' -F authorized_key=@<em>/path/to/key.pub</em>
 ```

--- a/content/v3/enterprise/management_console.md
+++ b/content/v3/enterprise/management_console.md
@@ -47,7 +47,7 @@ When using this endpoint, your Enterprise instance must have a password set. Thi
 1. If you're working directly with the API before accessing the web interface, you must pass in the password parameter to set your password.
 2. If you set up your instance via the web interface before accessing the API, your calls to this endpoint do not need the password parameter.
 
-You may also need to add the `-k` flag when using `curl`, sicne GitHub Enterprise uses a self-signed certificate before you [add your own SSL certificate](https://help.github.com/enterprise/admin/guides/installation/dns-hostname-subdomain-isolation-and-ssl/#ssl).
+You may also need to add the `-k` flag when using `curl`, since GitHub Enterprise uses a self-signed certificate before you [add your own SSL certificate](https://help.github.com/enterprise/admin/guides/installation/dns-hostname-subdomain-isolation-and-ssl/#ssl).
 
 {{/warning}}
 

--- a/content/v3/enterprise/management_console.md
+++ b/content/v3/enterprise/management_console.md
@@ -47,7 +47,7 @@ When using this endpoint, your Enterprise instance must have a password set. Thi
 1. If you're working directly with the API before accessing the web interface, you must pass in the password parameter to set your password.
 2. If you set up your instance via the web interface before accessing the API, your calls to this endpoint do not need the password parameter.
 
-You may also need to use the `-k` flag, as GitHub Enterprise uses a self-signed certificate before you [enable your own SSL certificate](https://help.github.com/enterprise/admin/guides/installation/dns-hostname-subdomain-isolation-and-ssl/#ssl).
+You may also need to add the `-k` flag when using `curl`, sicne GitHub Enterprise uses a self-signed certificate before you [add your own SSL certificate](https://help.github.com/enterprise/admin/guides/installation/dns-hostname-subdomain-isolation-and-ssl/#ssl).
 
 {{/warning}}
 

--- a/content/v3/enterprise/management_console.md
+++ b/content/v3/enterprise/management_console.md
@@ -18,7 +18,7 @@ If you don't want to provide a port number, you'll need to configure your tool t
 
 ## Authentication
 
-You need to pass your [Management Console password](https://help.github.com/enterprise/2.0/admin/articles/accessing-the-management-console/) as an authentication token to every Management Console API endpoint except [`/setup/api/start`](#upload-a-license-for-the-first-time).
+You need to pass your [Management Console password](https://help.github.com/enterprise/admin/articles/accessing-the-management-console/) as an authentication token to every Management Console API endpoint except [`/setup/api/start`](#upload-a-license-for-the-first-time).
 
 Use the `api_key` parameter to send this token with each request. For example:
 
@@ -69,7 +69,7 @@ For a list of the available settings, see [the `/setup/api/settings` endpoint](#
 ### Example
 
 ``` command-line
-$ curl -L -X POST 'http://<em>hostname</em>:<em>admin_port</em>/setup/api/start' -F license=@<em>/path/to/github-enterprise.ghl</em> -F "password=<em>your-amazing-password</em>" -F settings=&lt;<em>/path/to/settings.json</em>
+$ curl -L -X -k POST 'https://<em>hostname</em>:<em>admin_port</em>/setup/api/start' -F license=@<em>/path/to/github-enterprise.ghl</em> -F "password=<em>your-amazing-password</em>" -F settings=&lt;<em>/path/to/settings.json</em>
 ```
 
 ## Upgrade a license
@@ -259,7 +259,7 @@ Name | Type | Description
 ### Example
 
 ``` command-line
-$ curl -L -X POST 'http://api_key:<em>your-amazing-password</em>@<em>hostname</em>:<em>admin_port</em>/setup/api/settings/authorized-keys' -F authorized_key=@<em>/path/to/key.pub</em>
+$ curl -L -X -k POST 'https://api_key:<em>your-amazing-password</em>@<em>hostname</em>:<em>admin_port</em>/setup/api/settings/authorized-keys' -F authorized_key=@<em>/path/to/key.pub</em>
 ```
 
 ## Remove an authorized SSH key


### PR DESCRIPTION
In a recent customer question (in Front, so no thread available :frowning:) @davideg @brainstarr and I found that the example commands were missing a `-k` flag, and needed to be via https. The steps we documented for the customer are [here](https://gist.github.com/brainstarr/03aabb95bd4154ea3da6).

I'm not sure if this needs to be updated for each example on the page, but I can test that if needed.

I also removed a version number from a link to the Enterprise docs so that it redirects to the latest version.

/cc @github/api, @github/docs-platform, and @github/copy 