### PR TITLE
Added note to remind users: Capitalize HTTP verbs

### DIFF
--- a/content/v3.md
+++ b/content/v3.md
@@ -193,6 +193,8 @@ Verb | Description
 `PUT` | Used for replacing resources or collections. For `PUT` requests with no `body` attribute, be sure to set the `Content-Length` header to zero.
 `DELETE` |Used for deleting resources.
 
+When using HTTP verbs, be sure they are capitalized exactly as seen in the chart above.
+
 ## Authentication
 
 There are three ways to authenticate through GitHub API v3.  Requests that


### PR DESCRIPTION
After receiving an example customer service request while applying for a job I thought it should be noted in the documentation that (at least with curl) HTTP verbs need to be capitalized. 

This is confirmed by section 5.1.1 of http://www.ietf.org/rfc/rfc2616.txt
> The Method  token indicates the method to be performed on the resource identified by the Request-URI. The method is case-sensitive.
