### PR TITLE
Corrected milestone ref from due_date to due_on

### DIFF
--- a/content/v3/issues/milestones.md
+++ b/content/v3/issues/milestones.md
@@ -15,7 +15,7 @@ title: Issue Milestones
 Name | Type | Description
 -----|------|--------------
 `state`|`string` | The state of the milestone. Either `open`, `closed`, or `all`. Default: `open`
-`sort`|`string` | What to sort results by. Either `due_date` or `completeness`. Default: `due_date`
+`sort`|`string` | What to sort results by. Either `due_on` or `completeness`. Default: `due_on`
 `direction`|`string` | The direction of the sort. Either `asc` or `desc`. Default: `asc`
 
 


### PR DESCRIPTION
The docs referred to a `due_date` field which doesn't exist. The field is actually `due_on`.

Side note: The API does not return the referenced `completeness` field although apparently we can sort on it. I assume `completeness` is an internal field equals `open_issues` / (`open_issues` + `closed_issues`), and which is not exposed via the API.