### PR TITLE
Added information regarding auth 404 error

### DIFF
--- a/content/v3/oauth.md
+++ b/content/v3/oauth.md
@@ -78,9 +78,7 @@ header:
       <access_token>e72e16c7e42f292c6912e7710c838347ae178b4a</access_token>
     </OAuth>
     
-If your `client_id` or `client_secret` are incorrect, you will get a HTTP 404 error. 
-
-    {"error": "Not Found"}
+If your `client_id` or `client_secret` are incorrect, you will get a [Github HTTP 404 error](https://github.com/github/developer.github.com/blob/master/content/v3/troubleshooting.md#why-am-i-getting-a-404-error-on-a-repository-that-exists). 
 
 
 #### Requested scopes vs. granted scopes

--- a/content/v3/oauth.md
+++ b/content/v3/oauth.md
@@ -77,6 +77,10 @@ header:
       <scope>repo,gist</scope>
       <access_token>e72e16c7e42f292c6912e7710c838347ae178b4a</access_token>
     </OAuth>
+    
+If your `client_id` or `client_secret` are incorrect, you will get a HTTP 404 error. 
+
+    {"error": "Not Found"}
 
 
 #### Requested scopes vs. granted scopes


### PR DESCRIPTION
Added information about a common error when exchanging Github code for access_token. http://stackoverflow.com/search?q=https%3A%2F%2Fgithub.com%2Flogin%2Foauth%2Faccess_token
