### PR TITLE
Order the 'changes' in a consistent way

### DIFF
--- a/lib/changes_helper.rb
+++ b/lib/changes_helper.rb
@@ -17,7 +17,7 @@ module ChangesHelper
     else
       changes
     end.sort! do |x, y|
-      attribute_to_time(y[:created_at]) <=> attribute_to_time(x[:created_at])
+      [attribute_to_time(y[:created_at]), x[:title]] <=> [attribute_to_time(x[:created_at]), y[:title]]
     end
   end
 


### PR DESCRIPTION
This orders first by `created_at` descending (newest first) and then by `title` ascending.
This should not be TOO surprising, and doesn't trigger 600+ changed lines after each commit.
(Feed readers should also like this a little better than changing up the ordering every time)

Let me know what you think.