### PR TITLE
Add 2.5 release version

### DIFF
--- a/nanoc.yaml
+++ b/nanoc.yaml
@@ -12,7 +12,8 @@ pipeline_config:
   asset_root: https://a248.e.akamai.net/assets.github.com/images/icons
 
 versions:
-  - &latest_enterprise_version 2.4
+  - &latest_enterprise_version 2.5
+  - 2.4
   - 2.3
   - 2.2
   - 2.1


### PR DESCRIPTION
This adds a 2.5 release version as the latest version. This should prevent the old version showing up on developer.github.com

/cc @github/enterprise-on-prem @github/enterprise-docs 