### PR TITLE
Fix inconsistent req/res in issues.md

### DIFF
--- a/content/v3/issues.md
+++ b/content/v3/issues.md
@@ -102,7 +102,7 @@ Name | Type | Description
   :body      => "I'm having a problem with this.",
   :assignee  => "octocat",
   :milestone => 1,
-  :labels    => %w(Label1 Label2)
+  :labels    => %w(bug)
 %>
 
 ### Response
@@ -136,7 +136,7 @@ Name | Type | Description
   :assignee  => "octocat",
   :milestone => 1,
   :state     => "open",
-  :labels    => %w(Label1 Label2)
+  :labels    => %w(bug)
 %>
 
 ### Response


### PR DESCRIPTION
Found inconsistent mistakes to request and response examples -

part of request (in `Create an issue` & `Edit an issue`)
```json
  "labels": [
    "Label1",
    "Label2"
  ]
```

part of response (in`Create an issue` & `Edit an issue`)
```json
"labels": [
  {
    "url": "https://api.github.com/repos/octocat/Hello-World/labels/bug",
    "name": "bug",
    "color": "f29513"
  }
],
```

I changed request examples.