### PR TITLE
Add missing repository.deployments_url field

### DIFF
--- a/lib/webhooks/commit_comment.payload.json
+++ b/lib/webhooks/commit_comment.payload.json
@@ -94,6 +94,7 @@
     "notifications_url": "https://api.github.com/repos/baxterthehacker/public-repo/notifications{?since,all,participating}",
     "labels_url": "https://api.github.com/repos/baxterthehacker/public-repo/labels{/name}",
     "releases_url": "https://api.github.com/repos/baxterthehacker/public-repo/releases{/id}",
+    "deployments_url": "https://api.github.com/repos/baxterthehacker/public-repo/deployments",
     "created_at": "2015-05-05T23:40:12Z",
     "updated_at": "2015-05-05T23:40:12Z",
     "pushed_at": "2015-05-05T23:40:27Z",

--- a/lib/webhooks/create.payload.json
+++ b/lib/webhooks/create.payload.json
@@ -67,6 +67,7 @@
     "notifications_url": "https://api.github.com/repos/baxterthehacker/public-repo/notifications{?since,all,participating}",
     "labels_url": "https://api.github.com/repos/baxterthehacker/public-repo/labels{/name}",
     "releases_url": "https://api.github.com/repos/baxterthehacker/public-repo/releases{/id}",
+    "deployments_url": "https://api.github.com/repos/baxterthehacker/public-repo/deployments",
     "created_at": "2015-05-05T23:40:12Z",
     "updated_at": "2015-05-05T23:40:30Z",
     "pushed_at": "2015-05-05T23:40:38Z",

--- a/lib/webhooks/delete.payload.json
+++ b/lib/webhooks/delete.payload.json
@@ -65,6 +65,7 @@
     "notifications_url": "https://api.github.com/repos/baxterthehacker/public-repo/notifications{?since,all,participating}",
     "labels_url": "https://api.github.com/repos/baxterthehacker/public-repo/labels{/name}",
     "releases_url": "https://api.github.com/repos/baxterthehacker/public-repo/releases{/id}",
+    "deployments_url": "https://api.github.com/repos/baxterthehacker/public-repo/deployments",
     "created_at": "2015-05-05T23:40:12Z",
     "updated_at": "2015-05-05T23:40:30Z",
     "pushed_at": "2015-05-05T23:40:40Z",

--- a/lib/webhooks/deployment.payload.json
+++ b/lib/webhooks/deployment.payload.json
@@ -96,6 +96,7 @@
     "notifications_url": "https://api.github.com/repos/baxterthehacker/public-repo/notifications{?since,all,participating}",
     "labels_url": "https://api.github.com/repos/baxterthehacker/public-repo/labels{/name}",
     "releases_url": "https://api.github.com/repos/baxterthehacker/public-repo/releases{/id}",
+    "deployments_url": "https://api.github.com/repos/baxterthehacker/public-repo/deployments",
     "created_at": "2015-05-05T23:40:12Z",
     "updated_at": "2015-05-05T23:40:30Z",
     "pushed_at": "2015-05-05T23:40:38Z",

--- a/lib/webhooks/deployment_status.payload.json
+++ b/lib/webhooks/deployment_status.payload.json
@@ -126,6 +126,7 @@
     "notifications_url": "https://api.github.com/repos/baxterthehacker/public-repo/notifications{?since,all,participating}",
     "labels_url": "https://api.github.com/repos/baxterthehacker/public-repo/labels{/name}",
     "releases_url": "https://api.github.com/repos/baxterthehacker/public-repo/releases{/id}",
+    "deployments_url": "https://api.github.com/repos/baxterthehacker/public-repo/deployments",
     "created_at": "2015-05-05T23:40:12Z",
     "updated_at": "2015-05-05T23:40:30Z",
     "pushed_at": "2015-05-05T23:40:38Z",

--- a/lib/webhooks/fork.payload.json
+++ b/lib/webhooks/fork.payload.json
@@ -150,6 +150,7 @@
     "notifications_url": "https://api.github.com/repos/baxterthehacker/public-repo/notifications{?since,all,participating}",
     "labels_url": "https://api.github.com/repos/baxterthehacker/public-repo/labels{/name}",
     "releases_url": "https://api.github.com/repos/baxterthehacker/public-repo/releases{/id}",
+    "deployments_url": "https://api.github.com/repos/baxterthehacker/public-repo/deployments",
     "created_at": "2015-05-05T23:40:12Z",
     "updated_at": "2015-05-05T23:40:30Z",
     "pushed_at": "2015-05-05T23:40:27Z",

--- a/lib/webhooks/gollum.payload.json
+++ b/lib/webhooks/gollum.payload.json
@@ -72,6 +72,7 @@
     "notifications_url": "https://api.github.com/repos/baxterthehacker/public-repo/notifications{?since,all,participating}",
     "labels_url": "https://api.github.com/repos/baxterthehacker/public-repo/labels{/name}",
     "releases_url": "https://api.github.com/repos/baxterthehacker/public-repo/releases{/id}",
+    "deployments_url": "https://api.github.com/repos/baxterthehacker/public-repo/deployments",
     "created_at": "2015-05-05T23:40:12Z",
     "updated_at": "2015-05-05T23:40:12Z",
     "pushed_at": "2015-05-05T23:40:17Z",

--- a/lib/webhooks/issue_comment.payload.json
+++ b/lib/webhooks/issue_comment.payload.json
@@ -136,6 +136,7 @@
     "notifications_url": "https://api.github.com/repos/baxterthehacker/public-repo/notifications{?since,all,participating}",
     "labels_url": "https://api.github.com/repos/baxterthehacker/public-repo/labels{/name}",
     "releases_url": "https://api.github.com/repos/baxterthehacker/public-repo/releases{/id}",
+    "deployments_url": "https://api.github.com/repos/baxterthehacker/public-repo/deployments",
     "created_at": "2015-05-05T23:40:12Z",
     "updated_at": "2015-05-05T23:40:12Z",
     "pushed_at": "2015-05-05T23:40:27Z",

--- a/lib/webhooks/issues.payload.json
+++ b/lib/webhooks/issues.payload.json
@@ -108,6 +108,7 @@
     "notifications_url": "https://api.github.com/repos/baxterthehacker/public-repo/notifications{?since,all,participating}",
     "labels_url": "https://api.github.com/repos/baxterthehacker/public-repo/labels{/name}",
     "releases_url": "https://api.github.com/repos/baxterthehacker/public-repo/releases{/id}",
+    "deployments_url": "https://api.github.com/repos/baxterthehacker/public-repo/deployments",
     "created_at": "2015-05-05T23:40:12Z",
     "updated_at": "2015-05-05T23:40:12Z",
     "pushed_at": "2015-05-05T23:40:27Z",

--- a/lib/webhooks/member.payload.json
+++ b/lib/webhooks/member.payload.json
@@ -82,6 +82,7 @@
     "notifications_url": "https://api.github.com/repos/baxterthehacker/public-repo/notifications{?since,all,participating}",
     "labels_url": "https://api.github.com/repos/baxterthehacker/public-repo/labels{/name}",
     "releases_url": "https://api.github.com/repos/baxterthehacker/public-repo/releases{/id}",
+    "deployments_url": "https://api.github.com/repos/baxterthehacker/public-repo/deployments",
     "created_at": "2015-05-05T23:40:12Z",
     "updated_at": "2015-05-05T23:40:30Z",
     "pushed_at": "2015-05-05T23:40:40Z",

--- a/lib/webhooks/page_build.payload.json
+++ b/lib/webhooks/page_build.payload.json
@@ -93,6 +93,7 @@
     "notifications_url": "https://api.github.com/repos/baxterthehacker/public-repo/notifications{?since,all,participating}",
     "labels_url": "https://api.github.com/repos/baxterthehacker/public-repo/labels{/name}",
     "releases_url": "https://api.github.com/repos/baxterthehacker/public-repo/releases{/id}",
+    "deployments_url": "https://api.github.com/repos/baxterthehacker/public-repo/deployments",
     "created_at": "2015-05-05T23:40:12Z",
     "updated_at": "2015-05-05T23:40:12Z",
     "pushed_at": "2015-05-05T23:40:17Z",

--- a/lib/webhooks/ping.payload.json
+++ b/lib/webhooks/ping.payload.json
@@ -86,6 +86,7 @@
     "notifications_url": "https://api.github.com/repos/baxterthehacker/public-repo/notifications{?since,all,participating}",
     "labels_url": "https://api.github.com/repos/baxterthehacker/public-repo/labels{/name}",
     "releases_url": "https://api.github.com/repos/baxterthehacker/public-repo/releases{/id}",
+    "deployments_url": "https://api.github.com/repos/baxterthehacker/public-repo/deployments",
     "created_at": "2015-05-05T23:40:12Z",
     "updated_at": "2015-05-05T23:40:12Z",
     "pushed_at": "2015-05-05T23:40:15Z",

--- a/lib/webhooks/public.payload.json
+++ b/lib/webhooks/public.payload.json
@@ -62,6 +62,7 @@
     "notifications_url": "https://api.github.com/repos/baxterthehacker/public-repo/notifications{?since,all,participating}",
     "labels_url": "https://api.github.com/repos/baxterthehacker/public-repo/labels{/name}",
     "releases_url": "https://api.github.com/repos/baxterthehacker/public-repo/releases{/id}",
+    "deployments_url": "https://api.github.com/repos/baxterthehacker/public-repo/deployments",
     "created_at": "2015-05-05T23:40:12Z",
     "updated_at": "2015-05-05T23:40:41Z",
     "pushed_at": "2015-05-05T23:40:40Z",

--- a/lib/webhooks/pull_request.payload.json
+++ b/lib/webhooks/pull_request.payload.json
@@ -366,6 +366,7 @@
     "notifications_url": "https://api.github.com/repos/baxterthehacker/public-repo/notifications{?since,all,participating}",
     "labels_url": "https://api.github.com/repos/baxterthehacker/public-repo/labels{/name}",
     "releases_url": "https://api.github.com/repos/baxterthehacker/public-repo/releases{/id}",
+    "deployments_url": "https://api.github.com/repos/baxterthehacker/public-repo/deployments",
     "created_at": "2015-05-05T23:40:12Z",
     "updated_at": "2015-05-05T23:40:12Z",
     "pushed_at": "2015-05-05T23:40:26Z",

--- a/lib/webhooks/pull_request_review_comment.payload.json
+++ b/lib/webhooks/pull_request_review_comment.payload.json
@@ -400,6 +400,7 @@
     "notifications_url": "https://api.github.com/repos/baxterthehacker/public-repo/notifications{?since,all,participating}",
     "labels_url": "https://api.github.com/repos/baxterthehacker/public-repo/labels{/name}",
     "releases_url": "https://api.github.com/repos/baxterthehacker/public-repo/releases{/id}",
+    "deployments_url": "https://api.github.com/repos/baxterthehacker/public-repo/deployments",
     "created_at": "2015-05-05T23:40:12Z",
     "updated_at": "2015-05-05T23:40:12Z",
     "pushed_at": "2015-05-05T23:40:27Z",

--- a/lib/webhooks/push.payload.json
+++ b/lib/webhooks/push.payload.json
@@ -109,6 +109,7 @@
     "notifications_url": "https://api.github.com/repos/baxterthehacker/public-repo/notifications{?since,all,participating}",
     "labels_url": "https://api.github.com/repos/baxterthehacker/public-repo/labels{/name}",
     "releases_url": "https://api.github.com/repos/baxterthehacker/public-repo/releases{/id}",
+    "deployments_url": "https://api.github.com/repos/baxterthehacker/public-repo/deployments",
     "created_at": 1430869212,
     "updated_at": "2015-05-05T23:40:12Z",
     "pushed_at": 1430869217,

--- a/lib/webhooks/release.payload.json
+++ b/lib/webhooks/release.payload.json
@@ -102,6 +102,7 @@
     "notifications_url": "https://api.github.com/repos/baxterthehacker/public-repo/notifications{?since,all,participating}",
     "labels_url": "https://api.github.com/repos/baxterthehacker/public-repo/labels{/name}",
     "releases_url": "https://api.github.com/repos/baxterthehacker/public-repo/releases{/id}",
+    "deployments_url": "https://api.github.com/repos/baxterthehacker/public-repo/deployments",
     "created_at": "2015-05-05T23:40:12Z",
     "updated_at": "2015-05-05T23:40:30Z",
     "pushed_at": "2015-05-05T23:40:38Z",

--- a/lib/webhooks/repository.payload.json
+++ b/lib/webhooks/repository.payload.json
@@ -63,6 +63,7 @@
     "notifications_url": "https://api.github.com/repos/baxterandthehackers/new-repository/notifications{?since,all,participating}",
     "labels_url": "https://api.github.com/repos/baxterandthehackers/new-repository/labels{/name}",
     "releases_url": "https://api.github.com/repos/baxterandthehackers/new-repository/releases{/id}",
+    "deployments_url": "https://api.github.com/repos/baxterthehacker/public-repo/deployments",
     "created_at": "2014-12-03T16:39:25Z",
     "updated_at": "2014-12-03T16:39:25Z",
     "pushed_at": "2014-12-03T16:39:25Z",

--- a/lib/webhooks/status.payload.json
+++ b/lib/webhooks/status.payload.json
@@ -160,6 +160,7 @@
     "notifications_url": "https://api.github.com/repos/baxterthehacker/public-repo/notifications{?since,all,participating}",
     "labels_url": "https://api.github.com/repos/baxterthehacker/public-repo/labels{/name}",
     "releases_url": "https://api.github.com/repos/baxterthehacker/public-repo/releases{/id}",
+    "deployments_url": "https://api.github.com/repos/baxterthehacker/public-repo/deployments",
     "created_at": "2015-05-05T23:40:12Z",
     "updated_at": "2015-05-05T23:40:30Z",
     "pushed_at": "2015-05-05T23:40:39Z",

--- a/lib/webhooks/team_add.payload.json
+++ b/lib/webhooks/team_add.payload.json
@@ -72,6 +72,7 @@
     "notifications_url": "https://api.github.com/repos/baxterandthehackers/public-repo/notifications{?since,all,participating}",
     "labels_url": "https://api.github.com/repos/baxterandthehackers/public-repo/labels{/name}",
     "releases_url": "https://api.github.com/repos/baxterandthehackers/public-repo/releases{/id}",
+    "deployments_url": "https://api.github.com/repos/baxterthehacker/public-repo/deployments",
     "created_at": "2015-05-05T23:40:30Z",
     "updated_at": "2015-05-05T23:40:30Z",
     "pushed_at": "2015-05-05T23:40:27Z",

--- a/lib/webhooks/watch.payload.json
+++ b/lib/webhooks/watch.payload.json
@@ -63,6 +63,7 @@
     "notifications_url": "https://api.github.com/repos/baxterthehacker/public-repo/notifications{?since,all,participating}",
     "labels_url": "https://api.github.com/repos/baxterthehacker/public-repo/labels{/name}",
     "releases_url": "https://api.github.com/repos/baxterthehacker/public-repo/releases{/id}",
+    "deployments_url": "https://api.github.com/repos/baxterthehacker/public-repo/deployments",
     "created_at": "2015-05-05T23:40:12Z",
     "updated_at": "2015-05-05T23:40:30Z",
     "pushed_at": "2015-05-05T23:40:27Z",


### PR DESCRIPTION
I could only quickly get my hands on a handful of events, but I assume that each payload's elements are identical.