### PR TITLE
Add support for generating JSON from documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ tmp
 crash.log
 npm-debug.log
 build.txt
+json-dump

--- a/README.md
+++ b/README.md
@@ -95,6 +95,14 @@ Some actions return arrays.  You can modify the JSON by passing a block:
 <%= json(:issue) { |hash| [hash] } %>
 ```
 
+There is also a rake task for generating json files from the sample responses in the documentation:
+
+``` sh
+$ rake generate_json_from_sample_responses
+```
+
+The generated files will end up in `json-dump/`.
+
 ### Terminal blocks
 
 You can specify terminal blocks by using the `command-line` syntax highlighting.

--- a/Rakefile
+++ b/Rakefile
@@ -97,3 +97,13 @@ task :publish, [:no_commit_msg] => [:remove_tmp_dir, :remove_output_dir, :build]
     system 'git checkout master'
   end
 end
+
+desc "Generate JSON from the sample responses"
+task :generate_json_from_responses
+Dir[File.join(File.dirname(__FILE__), 'lib', 'responses', '*.rb')].each { |file| load file }
+FileUtils.mkdir_p(File.join(File.dirname(__FILE__), 'json-dump'))
+GitHub::Resources::Responses.constants.each { |constant|
+  File.open('json-dump/' + constant.to_s + '.json', 'w') { |file|
+    file.write(JSON.pretty_generate(GitHub::Resources::Helpers.get_resource(constant)))
+  }
+}


### PR DESCRIPTION
This pull request creates a rake task for generating json payloads as files from the documentation. Having the payload as files is useful for code generations of data objects (i.e for languages where serialising JSON to existing objects is necessary).