### PR TITLE
Manual backport of change to Managing Deploy Keys article

### DIFF
--- a/enterprise/2.0/guides/managing-deploy-keys/index.html
+++ b/enterprise/2.0/guides/managing-deploy-keys/index.html
@@ -143,9 +143,6 @@
 <h2>
 <a id="machine-users" class="anchor" href="#machine-users" aria-hidden="true"><span class="octicon octicon-link"></span></a>Machine users</h2>
 <p>If your server needs to access multiple repositories, you can choose to create a new GitHub Enterprise account and attach an SSH key that will be used exclusively for automation.  Since this GitHub Enterprise account won't be used by a human, it's called a machine user.  You can then <a href="https://help.github.com/articles/how-do-i-add-a-collaborator">add the machine user as collaborator</a> or <a href="https://help.github.com/articles/adding-organization-members-to-a-team">add the machine user to a team</a> with access to the repositories it needs to manipulate.  <strong>NOTE</strong>: Adding a machine user as a collaborator always grants read/write access.  Adding a machine user to a team grants the permissions of the team.</p>
-<div class="alert tip">
-<p><strong>Tip:</strong> Our <a href="https://help.github.com/articles/github-terms-of-service">terms of service</a> do mention that <em>'Accounts registered by "bots" or other automated methods are not permitted.'</em> and that <em>'One person or legal entity may not maintain more than one free account.'</em>  But don't fear, we won't send rabid lawyers out to hunt you down if you create a single machine user for your organization's deploy scripts. Creating a single machine user for your project or organization is totally cool.</p>
-</div>
 <h4>
 <a id="pros-3" class="anchor" href="#pros-3" aria-hidden="true"><span class="octicon octicon-link"></span></a>Pros</h4>
 <ul>

--- a/enterprise/2.1/guides/managing-deploy-keys/index.html
+++ b/enterprise/2.1/guides/managing-deploy-keys/index.html
@@ -143,9 +143,6 @@
 <h2>
 <a id="machine-users" class="anchor" href="#machine-users" aria-hidden="true"><span class="octicon octicon-link"></span></a>Machine users</h2>
 <p>If your server needs to access multiple repositories, you can choose to create a new GitHub Enterprise account and attach an SSH key that will be used exclusively for automation.  Since this GitHub Enterprise account won't be used by a human, it's called a machine user.  You can then <a href="https://help.github.com/articles/how-do-i-add-a-collaborator">add the machine user as collaborator</a> or <a href="https://help.github.com/articles/adding-organization-members-to-a-team">add the machine user to a team</a> with access to the repositories it needs to manipulate.  <strong>NOTE</strong>: Adding a machine user as a collaborator always grants read/write access.  Adding a machine user to a team grants the permissions of the team.</p>
-<div class="alert tip">
-<p><strong>Tip:</strong> Our <a href="https://help.github.com/articles/github-terms-of-service">terms of service</a> do mention that <em>'Accounts registered by "bots" or other automated methods are not permitted.'</em> and that <em>'One person or legal entity may not maintain more than one free account.'</em>  But don't fear, we won't send rabid lawyers out to hunt you down if you create a single machine user for your organization's deploy scripts. Creating a single machine user for your project or organization is totally cool.</p>
-</div>
 <h4>
 <a id="pros-3" class="anchor" href="#pros-3" aria-hidden="true"><span class="octicon octicon-link"></span></a>Pros</h4>
 <ul>

--- a/enterprise/2.2/guides/managing-deploy-keys/index.html
+++ b/enterprise/2.2/guides/managing-deploy-keys/index.html
@@ -143,9 +143,6 @@
 <h2>
 <a id="machine-users" class="anchor" href="#machine-users" aria-hidden="true"><span class="octicon octicon-link"></span></a>Machine users</h2>
 <p>If your server needs to access multiple repositories, you can choose to create a new GitHub Enterprise account and attach an SSH key that will be used exclusively for automation.  Since this GitHub Enterprise account won't be used by a human, it's called a machine user.  You can then <a href="https://help.github.com/articles/how-do-i-add-a-collaborator">add the machine user as collaborator</a> or <a href="https://help.github.com/articles/adding-organization-members-to-a-team">add the machine user to a team</a> with access to the repositories it needs to manipulate.  <strong>NOTE</strong>: Adding a machine user as a collaborator always grants read/write access.  Adding a machine user to a team grants the permissions of the team.</p>
-<div class="alert tip">
-<p><strong>Tip:</strong> Our <a href="https://help.github.com/articles/github-terms-of-service">terms of service</a> do mention that <em>'Accounts registered by "bots" or other automated methods are not permitted.'</em> and that <em>'One person or legal entity may not maintain more than one free account.'</em>  But don't fear, we won't send rabid lawyers out to hunt you down if you create a single machine user for your organization's deploy scripts. Creating a single machine user for your project or organization is totally cool.</p>
-</div>
 <h4>
 <a id="pros-3" class="anchor" href="#pros-3" aria-hidden="true"><span class="octicon octicon-link"></span></a>Pros</h4>
 <ul>

--- a/enterprise/2.3/guides/managing-deploy-keys/index.html
+++ b/enterprise/2.3/guides/managing-deploy-keys/index.html
@@ -143,9 +143,6 @@
 <h2>
 <a id="machine-users" class="anchor" href="#machine-users" aria-hidden="true"><span class="octicon octicon-link"></span></a>Machine users</h2>
 <p>If your server needs to access multiple repositories, you can choose to create a new GitHub Enterprise account and attach an SSH key that will be used exclusively for automation.  Since this GitHub Enterprise account won't be used by a human, it's called a machine user.  You can then <a href="https://help.github.com/articles/how-do-i-add-a-collaborator">add the machine user as collaborator</a> or <a href="https://help.github.com/articles/adding-organization-members-to-a-team">add the machine user to a team</a> with access to the repositories it needs to manipulate.  <strong>NOTE</strong>: Adding a machine user as a collaborator always grants read/write access.  Adding a machine user to a team grants the permissions of the team.</p>
-<div class="alert tip">
-<p><strong>Tip:</strong> Our <a href="https://help.github.com/articles/github-terms-of-service">terms of service</a> do mention that <em>'Accounts registered by "bots" or other automated methods are not permitted.'</em> and that <em>'One person or legal entity may not maintain more than one free account.'</em>  But don't fear, we won't send rabid lawyers out to hunt you down if you create a single machine user for your organization's deploy scripts. Creating a single machine user for your project or organization is totally cool.</p>
-</div>
 <h4>
 <a id="pros-3" class="anchor" href="#pros-3" aria-hidden="true"><span class="octicon octicon-link"></span></a>Pros</h4>
 <ul>

--- a/enterprise/2.4/guides/managing-deploy-keys/index.html
+++ b/enterprise/2.4/guides/managing-deploy-keys/index.html
@@ -12,7 +12,7 @@
   <link href="/enterprise/2.4/css/pygments.css" media="screen" rel="stylesheet" type="text/css">
   <script src="/enterprise/2.4/js/jquery.js" type="text/javascript"></script>
   <script src="/enterprise/2.4/js/documentation.js" type="text/javascript"></script>
-  
+
 </head>
 
 
@@ -171,12 +171,6 @@
 <h2 id="machine-users">Machine users</h2>
 
 <p>If your server needs to access multiple repositories, you can choose to create a new GitHub account and attach an SSH key that will be used exclusively for automation.  Since this GitHub account won’t be used by a human, it’s called a machine user.  You can then <a href="https://help.github.com/articles/how-do-i-add-a-collaborator">add the machine user as collaborator</a> or <a href="https://help.github.com/articles/adding-organization-members-to-a-team">add the machine user to a team</a> with access to the repositories it needs to manipulate.  <strong>NOTE</strong>: Adding a machine user as a collaborator always grants read/write access.  Adding a machine user to a team grants the permissions of the team.</p>
-
-<div class="alert">
-<p>
-<strong>Tip</strong>: Our <a href="https://help.github.com/articles/github-terms-of-service">terms of service</a> do mention that <em>'Accounts registered by "bots" or other automated methods are not permitted.'</em> and that <em>'One person or legal entity may not maintain more than one free account.'</em>  But don't fear, we won't send rabid lawyers out to hunt you down if you create a single machine user for your organization's deploy scripts. Creating a single machine user for your project or organization is totally cool.
-</p>
-</div>
 
 <h4 id="pros-3">Pros</h4>
 


### PR DESCRIPTION
The backport to 2.5 was done in https://github.com/github/developer.github.com/pull/1010.

This backports the same changes to the `guides/managing-deploy-keys/index.html` article to versions 2.0-2.4.

The change in the source files that this backports is in: https://github.com/github/developer.github.com/commit/cbf17ee3eedf43e5fd129045f365399101f20464