### PR TITLE
Fix section header in API - Pull Requests doc

### DIFF
--- a/content/v3/pulls.md
+++ b/content/v3/pulls.md
@@ -216,7 +216,7 @@ Name | Type | Description
   :documentation_url => "https://developer.github.com/v3/pulls/#merge-a-pull-request-merge-button"
 %>
 
-### Labels, assignees, and milestones
+## Labels, assignees, and milestones
 
 Every pull request is an issue, but not every issue is a pull request. For this reason, "shared" actions for both features, like manipulating assignees, labels and milestones, are provided within [the Issues API](/v3/issues).
 


### PR DESCRIPTION
["Labels, assignees, and milestones"](https://developer.github.com/v3/pulls/#labels-assignees-and-milestones) should be its own section (and listed in the TOC) but it was showing up as a sub-section of "Merge a pull request (Merge Button)"

![image](https://cloud.githubusercontent.com/assets/583255/13225061/24a6d804-d983-11e5-846c-82be3318dc2c.png)