### PR TITLE
Documentation update

### DIFF
--- a/content/guides/delivering-deployments.md
+++ b/content/guides/delivering-deployments.md
@@ -162,7 +162,7 @@ to simulate work that's going on. During that processing, we also make a call to
 switch the status to `pending`.
 
 After the deployment is finished, we set the status to `success`. You'll notice
-that this pattern is the exact same as when we you your CI statuses.
+that this pattern is the exact same as those which we display in your CI statuses.
 
 ## Conclusion
 

--- a/content/guides/delivering-deployments.md
+++ b/content/guides/delivering-deployments.md
@@ -161,8 +161,7 @@ to simulate work that's going on. During that processing, we also make a call to
 `create_deployment_status`, which lets a receiver know what's going on, as we
 switch the status to `pending`.
 
-After the deployment is finished, we set the status to `success`. You'll notice
-that this pattern is the exact same as those which we display in your CI statuses.
+After the deployment is finished, we set the status to `success`.
 
 ## Conclusion
 


### PR DESCRIPTION
There was a small typo in the documentation - I went ahead and corrected it.

`You'll notice that this pattern is the exact same as when we you your CI statuses.` -> `You'll notice that this pattern is the exact same as those which we display in your CI statuses.`

Hope this helps!