### PR TITLE
Update refs.md

### DIFF
--- a/content/v3/git/refs.md
+++ b/content/v3/git/refs.md
@@ -13,6 +13,8 @@ title: Git Refs
 The `ref` in the URL must be formatted as `heads/branch`, not just `branch`. For example, the call to get the data for a branch named `skunkworkz/featureA` would be:
 
     GET /repos/:owner/:repo/git/refs/heads/skunkworkz/featureA
+    
+If the `ref` doesn't exist in the repository, but existing refs start with `ref` they will be returned as an array.
 
 ### Response
 

--- a/content/v3/git/refs.md
+++ b/content/v3/git/refs.md
@@ -13,13 +13,26 @@ title: Git Refs
 The `ref` in the URL must be formatted as `heads/branch`, not just `branch`. For example, the call to get the data for a branch named `skunkworkz/featureA` would be:
 
     GET /repos/:owner/:repo/git/refs/heads/skunkworkz/featureA
-    
-If the `ref` doesn't exist in the repository, but existing refs start with `ref` they will be returned as an array.
-
-### Response
 
 <%= headers 200 %>
 <%= json :ref %>
+
+If the ref doesn't exist in the repository, but existing refs start with ref
+they will be returned as an array. For example, a call to get the data for a
+branch named `feature`, which doesn't exist, would return head refs
+including `featureA` and `featureB` which do.
+
+    GET /repos/:owner/:repo/git/refs/heads/feature
+
+<%= headers 200 %>
+<%= json :refs_matching %>
+
+If the ref doesn't match an existing ref or any prefixes a 404 will be returned.
+
+    GET /repos/:owner/:repo/git/refs/heads/ref-that-like-for-sure-totally-doesnt-exist
+
+<%= headers 404 %>
+<%= json :refs_not_found %>
 
 ## Get all References
 

--- a/content/v3/git/refs.md
+++ b/content/v3/git/refs.md
@@ -29,7 +29,7 @@ including `featureA` and `featureB` which do.
 
 If the ref doesn't match an existing ref or any prefixes a 404 will be returned.
 
-    GET /repos/:owner/:repo/git/refs/heads/ref-that-like-for-sure-totally-doesnt-exist
+    GET /repos/:owner/:repo/git/refs/heads/feature-branch-that-no-longer-exists
 
 <%= headers 404 %>
 <%= json :refs_not_found %>

--- a/content/v3/git/refs.md
+++ b/content/v3/git/refs.md
@@ -17,7 +17,7 @@ The `ref` in the URL must be formatted as `heads/branch`, not just `branch`. For
 <%= headers 200 %>
 <%= json :ref %>
 
-If the ref doesn't exist in the repository, but existing refs start with ref
+If the `ref` doesn't exist in the repository, but existing refs start with `ref`
 they will be returned as an array. For example, a call to get the data for a
 branch named `feature`, which doesn't exist, would return head refs
 including `featureA` and `featureB` which do.
@@ -27,7 +27,7 @@ including `featureA` and `featureB` which do.
 <%= headers 200 %>
 <%= json :refs_matching %>
 
-If the ref doesn't match an existing ref or any prefixes a 404 will be returned.
+If the `ref` doesn't match an existing ref or any prefixes a 404 will be returned.
 
     GET /repos/:owner/:repo/git/refs/heads/feature-branch-that-no-longer-exists
 

--- a/lib/responses/git.rb
+++ b/lib/responses/git.rb
@@ -422,6 +422,32 @@ module GitHub
           }
         }
       ]
+
+      REFS_MATCHING ||= [
+        {
+          "ref" => "refs/heads/feature-a",
+          "url" => "https://api.github.com/repos/octocat/Hello-World/git/refs/heads/feature-a",
+          "object" => {
+            "type" => "commit",
+            "sha" => "aa218f56b14c9653891f9e74264a383fa43fefbd",
+            "url" => "https://api.github.com/repos/octocat/Hello-World/git/commits/aa218f56b14c9653891f9e74264a383fa43fefbd"
+          }
+        },
+        {
+          "ref" => "refs/heads/feature-b",
+          "url" => "https://api.github.com/repos/octocat/Hello-World/git/refs/heads/feature-b",
+          "object" => {
+            "type" => "commit",
+            "sha" => "612077ae6dffb4d2fbd8ce0cccaa58893b07b5ac",
+            "url" => "https://api.github.com/repos/octocat/Hello-World/git/commits/612077ae6dffb4d2fbd8ce0cccaa58893b07b5ac"
+          }
+        }
+      ]
+
+      REFS_NOT_FOUND ||= {
+        "message" => "Not Found",
+        "documentation_url" => "https://developer.github.com/v3"
+      }
     end
   end
 end


### PR DESCRIPTION
Added mention of previously undocumented unmatched ref prefix returning an array of refs.

This could probably be made clearer so if anyone wants to give me some pointers on how to word it better or add examples I'd love to. I just wanted to get some mention of this behavior in the docs.