### PR TITLE
Changes `commit_id` description back to original

### DIFF
--- a/content/v3/pulls/comments.md
+++ b/content/v3/pulls/comments.md
@@ -62,7 +62,7 @@ Name | Type | Description
 Name | Type | Description
 -----|------|--------------
 `body`|`string` | **Required**. The text of the comment
-`commit_id`|`string` | **Required**. The SHA of the latest commit of the pull request to comment on.
+`commit_id`|`string` | **Required**. The SHA of the commit to comment on.
 `path`|`string` | **Required**. The relative path of the file to comment on.
 `position`|`integer` | **Required**. The line index in the diff to comment on.
 


### PR DESCRIPTION
This update partially reverts a change from #1020 - changing the description of the `commit_id` value in the Pull Request comment's input table.

In #1020, it was [suggested](https://github.com/github/developer.github.com/pull/1020/files#r54633578) that a note could convey _when_ the `commit_id` should be the latest commit, since:

> in some cases users may want to comment on a previous version of the PR via the API. In order to do so, they will need to pass a `commit_id` that's not equal to the "latest commit of the pull request".

/cc @tomasbjerre: I overlooked this in #1020, the note is still here, I just reverted the change to the table.