### PR TITLE
Updating GitHub API v3 wrapper link and name

### DIFF
--- a/content/libraries.md
+++ b/content/libraries.md
@@ -134,7 +134,7 @@ covers the entire API.
 * [Github Nette Extension][kdyby-github]
 * [GitHub API Easy Access][milo-github-api]
 * [GitHub bridge for Laravel][github-laravel]
-* [GitHub API v3 wrapper][github-api-v3-wrapper]
+* [PHP5.6|PHP7 Client & WebHook wrapper][flexyproject-githubapi]
 
 [github-php-client]: https://github.com/tan-tan-kanarek/github-php-client
 [php-github-api]: https://github.com/KnpLabs/php-github-api
@@ -144,7 +144,7 @@ covers the entire API.
 [kdyby-github]: https://github.com/kdyby/github
 [milo-github-api]: https://github.com/milo/github-api
 [github-laravel]: https://github.com/GrahamCampbell/Laravel-GitHub
-[github-api-v3-wrapper]: https://github.com/Scion-Framework/GitHubAPI
+[flexyproject-githubapi]: https://github.com/FlexyProject/GitHubAPI
 
 ## Python
 


### PR DESCRIPTION
Wrapper for GitHub API v3 as move from `Scion` to `FlexyProject` and offer now both PHP5.6 and PHP7 versions.
Link to repository as been updated.