### PR TITLE
Serialize the `search-index.json` alphabetically

### DIFF
--- a/content/search/search-index.json
+++ b/content/search/search-index.json
@@ -18,6 +18,9 @@
 %>
 <%=
   #output the generated tree
-  # TODO JSON.generate() always/on production builds?
-  JSON.pretty_generate(@output.sort{|a, b| a[:title] <=> b[:title]})
+  if ENV['RACK_ENV'] == "production"
+    JSON.generate(@output.sort{|a, b| a[:title] <=> b[:title]})
+  else
+    JSON.pretty_generate(@output.sort{|a, b| a[:title] <=> b[:title]})
+  end
 %>

--- a/content/search/search-index.json
+++ b/content/search/search-index.json
@@ -1,17 +1,23 @@
-[
-  <% if @config[:audience] %>
-    <% @preface = "/enterprise/#{@config[:audience]}" %>
-  <% end %>
-  <% @items.select { |item| !item.attributes[:hide_from_search] }.each do |item| %>
-  <% next if item[:filename].nil? || !item[:filename].end_with?('.md') %>
-  <% @path = item[:filename].split('/')[1..-1].join('/')[0..-4] %>
-  <% @path.chomp!('/index') if @path.end_with?('/index') %>
-  {
-    "title": "<%= clean_for_json(item[:title]) %>",
-    <%# Split off the directory name, join, then remove the '.md' extension %>
-    "url": "<%= @preface %>/<%= @path %>/",
-    "body": "<%= clean_for_json(item.compiled_content) %>"
-  },
-  <% end %>
-  {}
-]
+<%
+  #build the JSON tree
+  if @config[:audience]
+    @preface = "/enterprise/#{@config[:audience]}"
+  end
+  @output = []
+  @items.select { |item| !item.attributes[:hide_from_search] }.each do |item|
+    next if item[:filename].nil? || !item[:filename].end_with?('.md')
+    @path = item[:filename].split('/')[1..-1].join('/')[0..-4]
+    @path.chomp!('/index') if @path.end_with?('/index')
+
+    @output.push({
+        :title => "#{clean_for_json(item[:title])}",
+        :url   => "#{@preface}/#{@path}/",
+        :body  => "#{clean_for_json(item.compiled_content)}"
+      })
+  end
+%>
+<%=
+  #output the generated tree
+  # TODO JSON.generate() always/on production builds?
+  JSON.pretty_generate(@output.sort{|a, b| a[:title] <=> b[:title]})
+%>


### PR DESCRIPTION
This ensures that after deployment the `search-index.json` is in a consistent state so the order can be reproduced build after build.
Inspired by https://github.com/github/developer.github.com/commit/821c7fbbd08ffd8706d1a60370a50cb21f29af46#diff-3e285797a87ae049427e9c86def110cb