### PR TITLE
Don't escape the special characters for the JSON output

### DIFF
--- a/lib/strings.rb
+++ b/lib/strings.rb
@@ -15,12 +15,8 @@ module GitHub
       str.gsub(/[[:space:]]+/, ' ').strip
     end
 
-    def escape_quoted_characters(str)
-      str.gsub('\\', '\\\\\\').gsub('"', '\"')
-    end
-
     def clean_for_json(str)
-      strip_html(squish(escape_quoted_characters(str)))
+      strip_html(squish(str))
     end
   end
 end


### PR DESCRIPTION
This is a follow up to #1032, where the backslashes and quotes were escaped once by our code, and once by `JSON.generate()`.
Once is of course enough.
This cleans up the resulting JSON which allows us to pack more awesomeness in the data we send to the client! :boom: 