### PR TITLE
Reorder squish(), so it is performed on simple text

### DIFF
--- a/lib/strings.rb
+++ b/lib/strings.rb
@@ -16,7 +16,7 @@ module GitHub
     end
 
     def clean_for_json(str)
-      strip_html(squish(str))
+      squish(strip_html(str))
     end
   end
 end


### PR DESCRIPTION
This reduces all double spaces because it cleans up after `strip_html` turned the document into regular text.