### PR TITLE
incorrect key for commit head

### DIFF
--- a/content/v3/activity/events/types.md
+++ b/content/v3/activity/events/types.md
@@ -421,7 +421,7 @@ The Events API `PushEvent` payload is described in the table below. The example 
 Key | Type | Description
 ----|------|-------------
 `ref`|`string` | The full Git ref that was pushed. Example: `"refs/heads/master"`.
-`head`|`string` | The SHA of the most recent commit on `ref` after the push.
+`after`|`string` | The SHA of the most recent commit on `ref` after the push.
 `before`|`string` | The SHA of the most recent commit on `ref` before the push.
 `size`|`integer` | The number of commits in the push.
 `distinct_size`|`integer` | The number of distinct commits in the push.


### PR DESCRIPTION
Let me know if an example is necessary. Thanks!

``` json
{
  "after": "6b3d35683e4358345bc42981e0105e8ecf398b62", 
  "base_ref": null, 
  "before": "58ac6bd52c6af71d5b77fda4d3a8d59fa70e103d", 
  "commits": [...
```

> No "head" key found in the body.
