### PR TITLE
Changed comma to space in accordance with OAuth spec

### DIFF
--- a/content/v3/oauth.md
+++ b/content/v3/oauth.md
@@ -35,7 +35,7 @@ Name | Type | Description
 -----|------|--------------
 `client_id`|`string` | **Required**. The client ID you received from GitHub when you [registered](https://github.com/settings/applications/new).
 `redirect_uri`|`string` | The URL in your app where users will be sent after authorization. See details below about [redirect urls](#redirect-urls).
-`scope`|`string` | A comma separated list of [scopes](#scopes). If not provided, `scope` defaults to an empty list of scopes for users that don't have a valid token for the app. For users who do already have a valid token for the app, the user won't be shown the OAuth authorization page with the list of scopes. Instead, this step of the flow will automatically complete with the same scopes that were used last time the user completed the flow.
+`scope`|`string` | A space delimited list of [scopes](#scopes). If not provided, `scope` defaults to an empty list of scopes for users that don't have a valid token for the app. For users who do already have a valid token for the app, the user won't be shown the OAuth authorization page with the list of scopes. Instead, this step of the flow will automatically complete with the same scopes that were used last time the user completed the flow.
 `state`|`string` | An unguessable random string. It is used to protect against cross-site request forgery attacks.
 `allow_signup`|`string` | Whether or not unauthenticated users will be offered an option to sign up for GitHub during the OAuth flow. The default is `true`. Use `false` in the case that a policy prohibits signups.
 
@@ -204,11 +204,11 @@ Name | Description
 {% if page.version == 'dotcom' %}`admin:gpg_key`| Fully manage GPG keys.{% endif %}
 
 NOTE: Your application can request the scopes in the initial redirection. You
-can specify multiple scopes by separating them with a comma:
+can specify multiple scopes by separating them with a space:
 
     https://github.com/login/oauth/authorize?
       client_id=...&
-      scope=user,public_repo
+      scope=user%20public_repo
 
 ## Common errors for the authorization request
 


### PR DESCRIPTION
In the [OAuth 2 spec](https://tools.ietf.org/html/rfc6749#section-3.3), it says that:

> The value of the scope parameter is expressed as a list of space-delimited, case-sensitive strings.

I tested this, and it seems like GitHub's OAuth implementation allows both spaces (to be spec compliant) and commas to delimit scopes. I think we should change the documentation so it matches the spec, and what people expect. 

Otherwise the documentation will force people developing OAuth clients to make a deviation just for GitHub, even when it's not needed. 