### PR TITLE
GPG Keys documentation specify multiple potential Accept values

### DIFF
--- a/content/v3/git/commits.md
+++ b/content/v3/git/commits.md
@@ -72,7 +72,7 @@ Please see the [blog post](/changes/2016-04-04-git-signing-api-preview) for full
 
 To receive signature verification data in commit objects you must provide a custom [media type](/v3/media) in the `Accept` header:
 
-    application/vnd.github.cryptographer-preview+sha
+    application/vnd.github.cryptographer-preview
 
 {{/tip}}
 

--- a/content/v3/git/tags.md
+++ b/content/v3/git/tags.md
@@ -76,7 +76,7 @@ Please see the [blog post](/changes/2016-04-04-git-signing-api-preview) for full
 
 To receive signature verification data in tag objects you must provide a custom [media type](/v3/media) in the `Accept` header:
 
-    application/vnd.github.cryptographer-preview+sha
+    application/vnd.github.cryptographer-preview
 
 {{/tip}}
 

--- a/content/v3/repos/commits.md
+++ b/content/v3/repos/commits.md
@@ -98,7 +98,7 @@ Please see the [blog post](/changes/2016-04-04-git-signing-api-preview) for full
 
 To receive signature verification data in commit objects you must provide a custom [media type](/v3/media) in the `Accept` header:
 
-    application/vnd.github.cryptographer-preview+sha
+    application/vnd.github.cryptographer-preview
 
 {{/tip}}
 

--- a/content/v3/users/gpg_keys.md
+++ b/content/v3/users/gpg_keys.md
@@ -16,7 +16,7 @@ title: User GPG Keys
 
   To access the API you must provide a custom [media type](/v3/media) in the `Accept` header:
 
-      application/vnd.github.cryptographer-preview+sha
+      application/vnd.github.cryptographer-preview
 
 {{/tip}}
 


### PR DESCRIPTION
@alfhenrik pointed out over in [this issue](https://github.com/octokit/octokit.net/issues/1252#issuecomment-223782044) that the preview headers for GPG Keys are not consistent:

 - `application/vnd.github.cryptographer-preview` as per [the announcement blog post](https://developer.github.com/changes/2016-04-04-git-signing-api-preview/)
 - `  application/vnd.github.cryptographer-preview+sha` as per [the current docs](https://developer.github.com/v3/users/gpg_keys/)

I tested both values with a valid token and they fine, but this PR normalizes the docs to use `application/vnd.github.cryptographer-preview` to be consistent with most of our other preview APIs.

Let me know if anything is unclear here.