### PR TITLE
Assignees rename fields

### DIFF
--- a/lib/responses/issues_and_prs.rb
+++ b/lib/responses/issues_and_prs.rb
@@ -136,8 +136,8 @@ module GitHub
       ISSUE_WITH_ASSIGNEES ||= ISSUE.merge({
         "assignees" => [
           USER,
-          USER.merge("login" => "hubot"),
-          USER.merge("login" => "other_user")
+          HUBOT,
+          OTHER_USER
         ]
       })
 

--- a/lib/responses/issues_and_prs.rb
+++ b/lib/responses/issues_and_prs.rb
@@ -135,6 +135,7 @@ module GitHub
 
       ISSUE_WITH_ASSIGNEES ||= ISSUE.merge({
         "assignees" => [
+          USER,
           USER.merge("login" => "hubot"),
           USER.merge("login" => "other_user")
         ]

--- a/lib/responses/user.rb
+++ b/lib/responses/user.rb
@@ -21,6 +21,46 @@ module GitHub
         "site_admin"   => false
       }
 
+      HUBOT ||= {
+        "login"        => "hubot",
+        "id"           => 1,
+        "avatar_url"   => "https://github.com/images/error/hubot_happy.gif",
+        "gravatar_id"  => "",
+        "url"          => "https://api.github.com/users/hubot",
+        "html_url"     => "https://github.com/hubot",
+        "followers_url" => "https://api.github.com/users/hubot/followers",
+        "following_url" => "https://api.github.com/users/hubot/following{/other_user}",
+        "gists_url"    => "https://api.github.com/users/hubot/gists{/gist_id}",
+        "starred_url"  => "https://api.github.com/users/hubot/starred{/owner}{/repo}",
+        "subscriptions_url" => "https://api.github.com/users/hubot/subscriptions",
+        "organizations_url" => "https://api.github.com/users/hubot/orgs",
+        "repos_url"    => "https://api.github.com/users/hubot/repos",
+        "events_url"   => "https://api.github.com/users/hubot/events{/privacy}",
+        "received_events_url" => "https://api.github.com/users/hubot/received_events",
+        "type"         => "User",
+        "site_admin"   => true
+      }
+
+      OTHER_USER ||= {
+        "login"        => "other_user",
+        "id"           => 1,
+        "avatar_url"   => "https://github.com/images/error/other_user_happy.gif",
+        "gravatar_id"  => "",
+        "url"          => "https://api.github.com/users/other_user",
+        "html_url"     => "https://github.com/other_user",
+        "followers_url" => "https://api.github.com/users/other_user/followers",
+        "following_url" => "https://api.github.com/users/other_user/following{/other_user}",
+        "gists_url"    => "https://api.github.com/users/other_user/gists{/gist_id}",
+        "starred_url"  => "https://api.github.com/users/other_user/starred{/owner}{/repo}",
+        "subscriptions_url" => "https://api.github.com/users/other_user/subscriptions",
+        "organizations_url" => "https://api.github.com/users/other_user/orgs",
+        "repos_url"    => "https://api.github.com/users/other_user/repos",
+        "events_url"   => "https://api.github.com/users/other_user/events{/privacy}",
+        "received_events_url" => "https://api.github.com/users/other_user/received_events",
+        "type"         => "User",
+        "site_admin"   => false
+      }
+
       CONTRIBUTOR ||= USER.merge({
         "contributions" => 32
       })


### PR DESCRIPTION
I saw that the original user was not in the `assignees` list, and that the users in the `assignees` list weren't consistent.
This updates (merges) the `USER` with itself, updating all fields with the block. (if anyone knows of a nicer way, let me know)
This makes the data a little more realistic.
